### PR TITLE
Support for course reserves and email data

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,6 +9,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+    - name: update apt
+      run: sudo apt update
     - name: install dependency packages
       run: sudo apt install -y cmake g++ libcurl4-openssl-dev libpq-dev postgresql-server-dev-all rapidjson-dev unixodbc unixodbc-dev libsqlite3-dev
     - name: install catch2 testing framework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(ldp_obj OBJECT
 	src/dbup1.cpp
 	src/extract.cpp
 	src/init.cpp
+	src/initutil.cpp
 	src/ldp.cpp
 	src/log.cpp
 	src/merge.cpp

--- a/all.sh
+++ b/all.sh
@@ -4,6 +4,6 @@ set -x
 mkdir -p build
 cd build
 cmake ..
-make
+make -j 6
 ./ldp_test
 

--- a/all.sh
+++ b/all.sh
@@ -5,5 +5,5 @@ mkdir -p build
 cd build
 cmake ..
 make
-#./ldp_test
+./ldp_test
 

--- a/debug.sh
+++ b/debug.sh
@@ -4,6 +4,4 @@ set -x
 mkdir -p build
 cd build
 cmake -DDEBUG=ON -DOPTIMIZE=OFF ..
-make
-./ldp_test
-
+make ldp

--- a/debug.sh
+++ b/debug.sh
@@ -4,4 +4,5 @@ set -x
 mkdir -p build
 cd build
 cmake -DDEBUG=ON -DOPTIMIZE=OFF ..
-make ldp
+make -j 4 ldp
+

--- a/doc/Admin_Guide.md
+++ b/doc/Admin_Guide.md
@@ -23,9 +23,7 @@ reporting and analytics.
 LDP is not multitenant in the usual sense, and normally one LDP
 instance is deployed per library.  However, shared data from multiple
 libraries of a consortium can be stored in a single LDP instance, and
-in that case we refer to each of the libraries as a tenant.  _This
-consortial feature is not fully implemented but is planned for the
-near future._
+in that case we refer to each of the libraries as a tenant.
 
 This administrator guide covers installation and configuration of an
 LDP instance.
@@ -576,6 +574,8 @@ Reference
   * `okapi_user` (string; required) is the Okapi user name.
   * `okapi_password` (string; required) is the password for the
     specified Okapi user name.
+  * `tenant_id` (integer; optional) uniquely identifies a tenant in a
+    consortial LDP deployment.  The default value is `1`.
   * `direct_tables` (array; optional) is a list of tables that should
     be updated using direct extraction.  Only these tables may be
     included: `inventory_holdings`, `inventory_instances`, and

--- a/doc/Admin_Guide.md
+++ b/doc/Admin_Guide.md
@@ -182,12 +182,51 @@ Then:
 $ ./all.sh
 ```
 
-The `all.sh` script creates a `build/` subdirectory and builds the
-`ldp` executable there:
+The `all.sh` script creates a `build/` subdirectory and builds three
+executables there:
+
+* `ldp` is the LDP software.
+* `ldp_test` runs self-contained unit tests.
+* `ldp_testint` runs integration tests.
+
+After building these executables, the script also runs `ldp_test`.
+
+If there are no errors, the end of the output will include:
+
+```shell
+All tests passed
+```
+
+To run the LDP software:
 
 ```shell
 $ ./build/ldp
 ```
+
+### Running tests
+
+As mentioned above, the `all.sh` script runs the unit tests, but they
+can be run separately if needed:
+
+```shell
+$ ./build/ldp_test
+```
+
+Running the integration tests requires a FOLIO instance, as well as an
+LDP testbed instance with a PostgreSQL or Redshift database.  The
+contents of the LDP database will be destroyed by these tests; so
+please be careful that the correct database is used.  The
+`deployment_environment` configuration setting for the LDP testbed
+instance should be `testing` or `development`.  Also as a safety
+precaution, the setting `allow_destructive_tests` is required for
+integration tests.  The tests are run as:
+
+```shell
+$ ./build/ldp_testint -s -D DATADIR
+```
+
+where `DATADIR` is the data directory for the test database.  See
+below for an explanation of LDP data directories and configuration.
 
 
 4\. Database configuration

--- a/doc/Admin_Guide.md
+++ b/doc/Admin_Guide.md
@@ -522,19 +522,18 @@ does this by not updating certain tables that would contain personal
 data, for example `user_users`, and by deleting foreign key references
 to them from other tables.
 
-In the current development version of LDP, this anonymization process
-(though currently very limited) is enabled in new databases unless
+In the current development version of LDP, this anonymization process,
+though currently very limited, is enabled in new databases unless
 otherwise configured.
 
 Databases created with LDP 1.0 must be configured to support
-anonymization by changing the `disable_anonymization` settings to
-`false` (see below).
+anonymization by changing the `disable_anonymization` settings (see
+below).
 
-If it should be necessary to disable anonymization, this can be done
-by setting `disable_anonymization` to `true` in `ldpconf.json`, and by
-setting `disable_anonymization` to `TRUE` in the table
-`ldpconfig.general`.  Both are required to be set in order to disable
-anonymization.
+Anonymization can be disabled by setting `disable_anonymization` to
+`true` in `ldpconf.json`, and by setting `disable_anonymization` to
+`TRUE` in the table `ldpconfig.general`.  Both are required to be set
+in order to disable anonymization.
 
 __WARNING:  LDP does not provide a way to anonymize the database after
 personal data have been loaded into it.  For this reason, these

--- a/doc/Admin_Guide.md
+++ b/doc/Admin_Guide.md
@@ -396,8 +396,7 @@ __ldpconf.json__
             "okapi_user": "diku_admin",
             "okapi_password": "(okapi password here)"
         }
-    },
-    "disable_anonymization": true
+    }
 }
 ```
 
@@ -518,11 +517,29 @@ which may be protected by a firewall.
 7\. Data privacy
 ----------------
 
-LDP 1.0 stores personal data extracted from FOLIO.  The personal data
-are not currently anonymized.
+LDP can be configured to attempt "anonymization" of personal data.  It
+does this by not updating certain tables that would contain personal
+data, for example `user_users`, and by deleting foreign key references
+to them from other tables.
 
-LDP 1.1, which is under development, is planned to support
-anonymization of personal data.
+In the current development version of LDP, this anonymization process
+(though currently very limited) is enabled in new databases unless
+otherwise configured.
+
+Databases created with LDP 1.0 must be configured to support
+anonymization by changing the `disable_anonymization` settings to
+`false` (see below).
+
+If it should be necessary to disable anonymization, this can be done
+by setting `disable_anonymization` to `true` in `ldpconf.json`, and by
+setting `disable_anonymization` to `TRUE` in the table
+`ldpconfig.general`.  Both are required to be set in order to disable
+anonymization.
+
+__WARNING:  LDP does not provide a way to anonymize the database after
+personal data have been loaded into it.  For this reason, these
+settings should never be used unless you are absolutely sure that you
+want to store personal data in the LDP database.__
 
 
 Reference
@@ -575,9 +592,12 @@ Reference
   * `direct_database_password` (string; optional) is the password for
     the specified FOLIO database user name.
 
-* `disable_anonymization` (Boolean; required) when set to `true`,
-  disables anonymization of personal data.  In LDP 1.0, this value
-  must be set to `true`.
+* `disable_anonymization` (Boolean; optional) when set to `true`,
+  disables anonymization of personal data.  The default value is
+  `false`.  Please read the section on "Data privacy" above before
+  changing this setting.  As a safety precaution, the configuration
+  attribute `disable_anonymization` in table `ldpconfig.general` also
+  must be set.
 
 * `allow_destructive_tests` (Boolean; optional) when set to `true`,
   allows the LDP database to be overwritten by integration tests or

--- a/doc/Config_Guide.md
+++ b/doc/Config_Guide.md
@@ -57,8 +57,8 @@ Reference
   anonymization of personal data.  Please read the section on "Data
   privacy" in the [Administrator Guide](Admin_Guide.md) before
   changing this setting.  As a safety precaution, the configuration
-  setting `disableAnonymization` in `ldpconf.json` also must be set by
-  the LDP system administrator.
+  setting `disable_anonymization` in `ldpconf.json` also must be set
+  by the LDP system administrator.
 
 
 Further reading

--- a/doc/Config_Guide.md
+++ b/doc/Config_Guide.md
@@ -54,8 +54,11 @@ Reference
 * `enable_foreign_key_warnings` (BOOLEAN) is reserved for future use.
 
 * `disable_anonymization` (BOOLEAN) when set to `TRUE`, disables
-  anonymization of personal data.  In LDP 1.0, this value must be set
-  to `TRUE`.
+  anonymization of personal data.  Please read the section on "Data
+  privacy" in the [Administrator Guide](Admin_Guide.md) before
+  changing this setting.  As a safety precaution, the configuration
+  setting `disableAnonymization` in `ldpconf.json` also must be set by
+  the LDP system administrator.
 
 
 Further reading

--- a/etymoncpp/include/odbc.h
+++ b/etymoncpp/include/odbc.h
@@ -31,11 +31,7 @@ public:
     void exec_direct(odbc_stmt* stmt, const string& sql);
     bool fetch(odbc_stmt* stmt);
     void get_data(odbc_stmt* stmt, uint16_t column, string* data);
-    void start_transaction();
-    void commit();
-    void rollback();
 private:
-    void set_auto_commit(bool autoCommit);
     void exec_direct_stmt(odbc_stmt* stmt, const string& sql);
 };
 
@@ -50,6 +46,7 @@ class odbc_tx {
 public:
     odbc_conn* conn;
     odbc_tx(odbc_conn* conn);
+    ~odbc_tx();
     void commit();
     void rollback();
 private:

--- a/examples/ldpconf.json
+++ b/examples/ldpconf.json
@@ -11,7 +11,6 @@
             "okapi_user": "diku_admin",
             "okapi_password": "(okapi password here)"
         }
-    },
-    "disable_anonymization": true
+    }
 }
 

--- a/src/anonymize.cpp
+++ b/src/anonymize.cpp
@@ -6,9 +6,9 @@ static set<pair<string,string>> personal_data_fields = {
     {"circulation_loans", "/userId"}
 };
 
-bool is_personal_data_field(const TableSchema& table, const string& field)
+bool is_personal_data_field(const table_schema& table, const string& field)
 {
-    pair<string,string> p = pair<string,string>(table.tableName, field);
+    pair<string,string> p = pair<string,string>(table.name, field);
     return (personal_data_fields.find(p) != personal_data_fields.end());
 }
 

--- a/src/anonymize.cpp
+++ b/src/anonymize.cpp
@@ -1,24 +1,14 @@
-#include <cstring>
+#include <set>
 
 #include "anonymize.h"
 
-bool possiblePersonalData(const string& field)
-{
-    const char* f = field.c_str();
-    return (
-            (strcmp(f, "/id") != 0) &&
-            (strcmp(f, "/active") != 0) &&
-            (strcmp(f, "/type") != 0) &&
-            (strcmp(f, "/patronGroup") != 0) &&
-            (strcmp(f, "/enrollmentDate") != 0) &&
-            (strcmp(f, "/expirationDate") != 0) &&
-            (strcmp(f, "/meta") != 0) &&
-            (strcmp(f, "/proxyFor") != 0) &&
-            (strcmp(f, "/createdDate") != 0) &&
-            (strcmp(f, "/updatedDate") != 0) &&
-            (strcmp(f, "/metadata") != 0) &&
-            (strcmp(f, "/tags") != 0)
-           );
-}
+static set<pair<string,string>> personal_data_fields = {
+    {"circulation_loans", "/userId"}
+};
 
+bool is_personal_data_field(const TableSchema& table, const string& field)
+{
+    pair<string,string> p = pair<string,string>(table.tableName, field);
+    return (personal_data_fields.find(p) != personal_data_fields.end());
+}
 

--- a/src/anonymize.h
+++ b/src/anonymize.h
@@ -3,7 +3,7 @@
 
 #include "schema.h"
 
-bool is_personal_data_field(const TableSchema& table, const string& field);
+bool is_personal_data_field(const table_schema& table, const string& field);
 
 #endif
 

--- a/src/anonymize.h
+++ b/src/anonymize.h
@@ -1,11 +1,9 @@
 #ifndef LDP_ANONYMIZE_H
 #define LDP_ANONYMIZE_H
 
-#include <string>
+#include "schema.h"
 
-using namespace std;
-
-bool possiblePersonalData(const string& field);
+bool is_personal_data_field(const TableSchema& table, const string& field);
 
 #endif
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -104,23 +104,22 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
         if (value->IsString() == false)
             throw_invalid_data_type(key, "string");
         string source_name = value->GetString();
-        fprintf(stderr, "\"%s\"\n", source_name.c_str()); /////////////////////
+
+        // TODO Check if source_name is already in enable_sources, and if so,
+        // flag the duplication (throw error).
+
         // Look up source details.
         data_source source;
         source.source_name = source_name;
         string prefix = "/sources/" + source_name + "/";
         // Okapi URL.
         get_string(prefix + "okapi_url", true, &(source.okapi_url));
-        fprintf(stderr, "\t\"%s\"\n", source.okapi_url.c_str()); //////////////
         // Okapi tenant.
         get_string(prefix + "okapi_tenant", true, &(source.okapi_tenant));
-        fprintf(stderr, "\t\"%s\"\n", source.okapi_tenant.c_str()); ///////////
         // Okapi user.
         get_string(prefix + "okapi_user", true, &(source.okapi_user));
-        fprintf(stderr, "\t\"%s\"\n", source.okapi_user.c_str()); /////////////
         // Okapi password.
         get_string(prefix + "okapi_password", true, &(source.okapi_password));
-        fprintf(stderr, "\t\"%s\"\n", source.okapi_password.c_str()); /////////
         // Tenant ID.
         int tenant_id = 1;
         get_int(prefix + "tenant_id", true, &tenant_id);
@@ -129,7 +128,6 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
         else
             throw_value_out_of_range(prefix + "tenant_id",
                                      to_string(tenant_id), "1 to 32767");
-        fprintf(stderr, "\t\"%s\"\n", to_string(source.tenant_id).c_str()); ///
         // Direct extraction.
         direct_extraction direct;
         // Loop through direct_tables JSON array.
@@ -142,7 +140,6 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
             if (value->IsString() == false)
                 throw_invalid_data_type(key, "string");
             string table_name = value->GetString();
-            fprintf(stderr, "\t\t\"%s\"\n", table_name.c_str()); //////////////
 
             direct.table_names.push_back(table_name);
             direct_index++;
@@ -151,11 +148,9 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
         // Direct database name.
         get_string(prefix + "direct_database_name", false,
                    &(direct.database_name));
-        fprintf(stderr, "\t\t\"%s\"\n", direct.database_name.c_str()); ////////
         // Direct database host.
         get_string(prefix + "direct_database_host", false,
                    &(direct.database_host));
-        fprintf(stderr, "\t\t\"%s\"\n", direct.database_host.c_str()); ////////
         // Port number.
         int port = 0;
         bool found = get_int(prefix + "direct_database_port", false, &port);
@@ -166,15 +161,12 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
                 throw_value_out_of_range(prefix + "direct_database_port",
                                          to_string(port), "1 to 65535");
         }
-        fprintf(stderr, "\t\t\"%s\"\n", direct.database_port.c_str()); ////////
         // Direct database user.
         get_string(prefix + "direct_database_user", false,
                    &(direct.database_user));
-        fprintf(stderr, "\t\t\"%s\"\n", direct.database_user.c_str()); ////////
         // Direct database password.
         get_string(prefix + "direct_database_password", false,
                    &(direct.database_password));
-        fprintf(stderr, "\t\t\"%s\"\n", direct.database_password.c_str()); ////
         // Add direct extractino data to source.
         source.direct = direct;
         // Append source to list.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -27,6 +27,164 @@ ldp_config::ldp_config(const string& conf)
     jsondoc.ParseStream<pflags>(is);
 }
 
+static void throw_invalid_data_type(const string& key,
+                                    const string& expected_type)
+{
+    throw runtime_error(
+            "Invalid data type in configuration setting:\n"
+            "    Key: " + key + "\n"
+            "    Expected type: " + expected_type);
+}
+
+static void throw_value_out_of_range(const string& key,
+                                     const string& value,
+                                     const string& range)
+{
+    throw runtime_error(
+            "Value for configuration setting is out of range:\n"
+            "    Key: " + key + "\n"
+            "    Value: " + value + "\n"
+            "    Range: " + range);
+}
+
+static void throw_required_value_not_found(const string& key)
+{
+    throw runtime_error(
+            "Required configuration value not found:\n"
+            "    Key: " + key);
+}
+
+const json::Value* ldp_config::get_json_pointer(const string& key) const
+{
+        return json::Pointer(key.c_str()).Get(jsondoc);
+}
+
+bool ldp_config::get_string(const string& key, bool required,
+                            string* value) const
+{
+    const json::Value* v = get_json_pointer(key);
+    if (v == nullptr) {
+        if (required)
+            throw_required_value_not_found(key);
+        else
+            return false;
+    }
+    if (v->IsString() == false)
+        throw_invalid_data_type(key, "string");
+    *value = v->GetString();
+    return true;
+}
+
+bool ldp_config::get_int(const string& key, bool required,
+                         int* value) const
+{
+    const json::Value* v = get_json_pointer(key);
+    if (v == nullptr) {
+        if (required)
+            throw_required_value_not_found(key);
+        else
+            return false;
+    }
+    if (v->IsInt() == false)
+        throw_invalid_data_type(key, "integer");
+    *value = v->GetInt();
+    return true;
+}
+
+void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
+{
+    enable_sources->clear();
+    // Loop through enable_sources JSON array.
+    int source_index = 0;
+    while (true) {
+        string key = "/enable_sources/" + to_string(source_index);
+        const json::Value* value = get_json_pointer(key);
+        if (value == nullptr)
+            break;
+        if (value->IsString() == false)
+            throw_invalid_data_type(key, "string");
+        string source_name = value->GetString();
+        fprintf(stderr, "\"%s\"\n", source_name.c_str()); /////////////////////
+        // Look up source details.
+        data_source source;
+        source.source_name = source_name;
+        string prefix = "/sources/" + source_name + "/";
+        // Okapi URL.
+        get_string(prefix + "okapi_url", true, &(source.okapi_url));
+        fprintf(stderr, "\t\"%s\"\n", source.okapi_url.c_str()); //////////////
+        // Okapi tenant.
+        get_string(prefix + "okapi_tenant", true, &(source.okapi_tenant));
+        fprintf(stderr, "\t\"%s\"\n", source.okapi_tenant.c_str()); ///////////
+        // Okapi user.
+        get_string(prefix + "okapi_user", true, &(source.okapi_user));
+        fprintf(stderr, "\t\"%s\"\n", source.okapi_user.c_str()); /////////////
+        // Okapi password.
+        get_string(prefix + "okapi_password", true, &(source.okapi_password));
+        fprintf(stderr, "\t\"%s\"\n", source.okapi_password.c_str()); /////////
+        // Tenant ID.
+        int tenant_id = 1;
+        get_int(prefix + "tenant_id", true, &tenant_id);
+        if (1 <= tenant_id && tenant_id <= 32767)
+            source.tenant_id = (int16_t) tenant_id;
+        else
+            throw_value_out_of_range(prefix + "tenant_id",
+                                     to_string(tenant_id), "1 to 32767");
+        fprintf(stderr, "\t\"%s\"\n", to_string(source.tenant_id).c_str()); ///
+        // Direct extraction.
+        direct_extraction direct;
+        // Loop through direct_tables JSON array.
+        int direct_index = 0;
+        while (true) {
+            string key = prefix + "direct_tables/" + to_string(direct_index);
+            const json::Value* value = get_json_pointer(key);
+            if (value == nullptr)
+                break;
+            if (value->IsString() == false)
+                throw_invalid_data_type(key, "string");
+            string table_name = value->GetString();
+            fprintf(stderr, "\t\t\"%s\"\n", table_name.c_str()); //////////////
+
+            direct.table_names.push_back(table_name);
+            direct_index++;
+        }
+        // Additional direct extraction settings.
+        // Direct database name.
+        get_string(prefix + "direct_database_name", false,
+                   &(direct.database_name));
+        fprintf(stderr, "\t\t\"%s\"\n", direct.database_name.c_str()); ////////
+        // Direct database host.
+        get_string(prefix + "direct_database_host", false,
+                   &(direct.database_host));
+        fprintf(stderr, "\t\t\"%s\"\n", direct.database_host.c_str()); ////////
+        // Port number.
+        int port = 0;
+        bool found = get_int(prefix + "direct_database_port", false, &port);
+        if (found) {
+            if (1 <= port && port <= 65535)
+                direct.database_port = to_string(port);
+            else
+                throw_value_out_of_range(prefix + "direct_database_port",
+                                         to_string(port), "1 to 65535");
+        }
+        fprintf(stderr, "\t\t\"%s\"\n", direct.database_port.c_str()); ////////
+        // Direct database user.
+        get_string(prefix + "direct_database_user", false,
+                   &(direct.database_user));
+        fprintf(stderr, "\t\t\"%s\"\n", direct.database_user.c_str()); ////////
+        // Direct database password.
+        get_string(prefix + "direct_database_password", false,
+                   &(direct.database_password));
+        fprintf(stderr, "\t\t\"%s\"\n", direct.database_password.c_str()); ////
+        // Add direct extractino data to source.
+        source.direct = direct;
+        // Append source to list.
+        enable_sources->push_back(source);
+        source_index++;
+    }; // while
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 bool ldp_config::get(const string& key, string* value) const
 {
     if (const json::Value* v = json::Pointer(key.c_str()).Get(jsondoc)) {
@@ -57,7 +215,7 @@ bool ldp_config::get_bool(const string& key, bool* value) const
     }
 }
 
-bool ldp_config::get_int(const string& key, int* value) const
+bool ldp_config::old_get_int(const string& key, int* value) const
 {
     if (const json::Value* v = json::Pointer(key.c_str()).Get(jsondoc)) {
         if (v->IsInt() == false)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -128,6 +128,9 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
         else
             throw_value_out_of_range(prefix + "tenant_id",
                                      to_string(tenant_id), "1 to 32767");
+
+        // TODO Ensure tenant_id is unique.
+
         // Direct extraction.
         direct_extraction direct;
         // Loop through direct_tables JSON array.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -122,7 +122,7 @@ void ldp_config::get_enable_sources(vector<data_source>* enable_sources) const
         get_string(prefix + "okapi_password", true, &(source.okapi_password));
         // Tenant ID.
         int tenant_id = 1;
-        get_int(prefix + "tenant_id", true, &tenant_id);
+        get_int(prefix + "tenant_id", false, &tenant_id);
         if (1 <= tenant_id && tenant_id <= 32767)
             source.tenant_id = (int16_t) tenant_id;
         else

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,7 +8,7 @@
 
 constexpr json::ParseFlag pflags = json::kParseTrailingCommasFlag;
 
-config::config(const string& conf)
+ldp_config::ldp_config(const string& conf)
 {
     string config_file;
     if (conf != "") {
@@ -18,7 +18,7 @@ config::config(const string& conf)
         config_file = s ? s : "";
         etymon::trim(&config_file);
         if (config_file.empty())
-            throw runtime_error("configuration file not specified");
+            throw runtime_error("Configuration file not specified");
     }
     // Load and parse JSON file.
     etymon::file f(config_file, "r");
@@ -27,7 +27,7 @@ config::config(const string& conf)
     jsondoc.ParseStream<pflags>(is);
 }
 
-bool config::get(const string& key, string* value) const
+bool ldp_config::get(const string& key, string* value) const
 {
     if (const json::Value* v = json::Pointer(key.c_str()).Get(jsondoc)) {
         if (v->IsString() == false)
@@ -42,7 +42,7 @@ bool config::get(const string& key, string* value) const
     }
 }
 
-bool config::get_bool(const string& key, bool* value) const
+bool ldp_config::get_bool(const string& key, bool* value) const
 {
     if (const json::Value* v = json::Pointer(key.c_str()).Get(jsondoc)) {
         if (v->IsBool() == false)
@@ -57,7 +57,7 @@ bool config::get_bool(const string& key, bool* value) const
     }
 }
 
-bool config::get_int(const string& key, int* value) const
+bool ldp_config::get_int(const string& key, int* value) const
 {
     if (const json::Value* v = json::Pointer(key.c_str()).Get(jsondoc)) {
         if (v->IsInt() == false)
@@ -72,16 +72,15 @@ bool config::get_int(const string& key, int* value) const
     }
 }
 
-void config::get_required(const string& key, string* value) const
+void ldp_config::get_required(const string& key, string* value) const
 {
     if (!get(key, value))
-        throw runtime_error("configuration value not found: " + key);
+        throw runtime_error("Configuration value not found: " + key);
 }
 
-void config::get_optional(const string& key, string* value) const
+void ldp_config::get_optional(const string& key, string* value) const
 {
-    if (!get(key, value)) {
+    if (!get(key, value))
         value->clear();
-    }
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -6,9 +6,9 @@
 using namespace std;
 namespace json = rapidjson;
 
-class config {
+class ldp_config {
 public:
-    config(const string& conf);
+    ldp_config(const string& conf);
     bool get(const string& key, string* value) const;
     bool get_int(const string& key, int* value) const;
     bool get_bool(const string& key, bool* value) const;

--- a/src/config.h
+++ b/src/config.h
@@ -1,6 +1,7 @@
 #ifndef LDP_CONFIG_H
 #define LDP_CONFIG_H
 
+#include "options.h"
 #include "rapidjson/document.h"
 
 using namespace std;
@@ -9,12 +10,17 @@ namespace json = rapidjson;
 class ldp_config {
 public:
     ldp_config(const string& conf);
+    void get_enable_sources(vector<data_source>* enable_sources) const;
+    bool get_string(const string& key, bool required, string* value) const;
+    bool get_int(const string& key, bool required, int* value) const;
+    ///////////////////////////////////////////////////////////////////////////
     bool get(const string& key, string* value) const;
-    bool get_int(const string& key, int* value) const;
+    bool old_get_int(const string& key, int* value) const;
     bool get_bool(const string& key, bool* value) const;
     void get_required(const string& key, string* value) const;
     void get_optional(const string& key, string* value) const;
 private:
+    const json::Value* get_json_pointer(const string& key) const;
     json::Document jsondoc;
 };
 

--- a/src/dbtype.cpp
+++ b/src/dbtype.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include "dbtype.h"
 
 dbtype::dbtype(etymon::odbc_conn* conn)

--- a/src/dbtype.cpp
+++ b/src/dbtype.cpp
@@ -1,5 +1,3 @@
-#include <stdexcept>
-
 #include "dbtype.h"
 
 dbtype::dbtype(etymon::odbc_conn* conn)
@@ -54,7 +52,8 @@ void dbtype::rename_sequence(const string& sequence_name,
 {
     switch (dbt) {
         case dbsys::postgresql:
-            *sql = "ALTER SEQUENCE IF EXISTS\n"
+            *sql =
+                "ALTER SEQUENCE IF EXISTS\n"
                 "    " + sequence_name + "\n"
                 "    RENAME TO " + new_sequence_name + ";";
             return;
@@ -72,7 +71,8 @@ void dbtype::create_sequence(const string& sequence_name, int64_t start,
 {
     switch (dbt) {
         case dbsys::postgresql:
-            *sql = "CREATE SEQUENCE " + sequence_name + "\n"
+            *sql =
+                "CREATE SEQUENCE " + sequence_name + "\n"
                 "    START " + to_string(start) + ";";
             return;
         case dbsys::redshift:
@@ -90,7 +90,8 @@ void dbtype::auto_increment_type(int64_t start, bool named_sequence,
     switch (dbt) {
         case dbsys::postgresql:
             if (named_sequence)
-                *sql = "BIGINT NOT NULL\n"
+                *sql =
+                    "BIGINT NOT NULL\n"
                     "        DEFAULT\n"
                     "        nextval('" + sequence_name +
                     "')";
@@ -112,7 +113,8 @@ void dbtype::alter_sequence_owned_by(const string& sequence_name,
 {
     switch (dbt) {
         case dbsys::postgresql:
-            *sql = "ALTER SEQUENCE " + sequence_name + "\n"
+            *sql =
+                "ALTER SEQUENCE " + sequence_name + "\n"
                 "    OWNED BY " + table_column_name + ";";
             return;
         case dbsys::redshift:

--- a/src/dbtype.h
+++ b/src/dbtype.h
@@ -1,11 +1,7 @@
 #ifndef LDP_DBTYPE_H
 #define LDP_DBTYPE_H
 
-#include <string>
-
 #include "../etymoncpp/include/odbc.h"
-
-using namespace std;
 
 enum class dbsys {
     postgresql,

--- a/src/dbup1.cpp
+++ b/src/dbup1.cpp
@@ -1,13 +1,4 @@
-#include <experimental/filesystem>
-#include <sstream>
-#include <stdexcept>
-
-#include "dbtype.h"
 #include "dbup1.h"
-#include "init.h"
-#include "log.h"
-
-namespace fs = std::experimental::filesystem;
 
 void database_upgrade_1(database_upgrade_options* opt)
 {
@@ -615,8 +606,6 @@ void database_upgrade_7(database_upgrade_options* opt)
 
 void database_upgrade_8(database_upgrade_options* opt)
 {
-    //idmap::schemaUpgradeRemoveNewColumn(opt->datadir);
-
     string sql = "UPDATE ldpsystem.main SET ldp_schema_version = 8;";
     fprintf(opt->ulog, "%s\n", sql.c_str());
     fflush(opt->ulog);

--- a/src/dbup1.cpp
+++ b/src/dbup1.cpp
@@ -982,3 +982,179 @@ void database_upgrade_11(database_upgrade_options* opt)
     fflush(opt->ulog);
 }
 
+void database_upgrade_12(database_upgrade_options* opt)
+{
+    // Table: ldpconfig.general
+
+    // Column: disable_anonymization
+    // Drop default
+    string sql =
+        "ALTER TABLE ldpconfig.general\n"
+        "    ALTER COLUMN disable_anonymization DROP DEFAULT;";
+    fprintf(opt->ulog, "%s\n", sql.c_str());
+    fflush(opt->ulog);
+    opt->conn->exec(sql);
+    fprintf(opt->ulog, "-- Committed\n");
+    fflush(opt->ulog);
+
+    // Column: update_all_tables
+    // Add column
+    sql =
+        "ALTER TABLE ldpconfig.general\n"
+        "    ADD COLUMN update_all_tables\n"
+        "    BOOLEAN;";
+    fprintf(opt->ulog, "%s\n", sql.c_str());
+    fflush(opt->ulog);
+    opt->conn->exec(sql);
+    fprintf(opt->ulog, "-- Committed\n");
+    fflush(opt->ulog);
+    // Update value
+    sql =
+        "UPDATE ldpconfig.general\n"
+        "    SET update_all_tables = TRUE;";
+    fprintf(opt->ulog, "%s\n", sql.c_str());
+    fflush(opt->ulog);
+    opt->conn->exec(sql);
+    fprintf(opt->ulog, "-- Committed\n");
+    fflush(opt->ulog);
+    // Set not null
+    sql =
+        "ALTER TABLE ldpconfig.general\n"
+        "    ALTER COLUMN update_all_tables SET NOT NULL;";
+    fprintf(opt->ulog, "%s\n", sql.c_str());
+    fflush(opt->ulog);
+    opt->conn->exec(sql);
+    fprintf(opt->ulog, "-- Committed\n");
+    fflush(opt->ulog);
+
+    // Table: ldpconfig.update_tables
+    // Create table
+    sql =
+        "CREATE TABLE ldpconfig.update_tables (\n"
+        "    enable_update BOOLEAN NOT NULL,\n"
+        "    table_name VARCHAR(63) NOT NULL,\n"
+        "    tenant_id SMALLINT NOT NULL\n"
+        ");";
+    fprintf(opt->ulog, "%s\n", sql.c_str());
+    fflush(opt->ulog);
+    opt->conn->exec(sql);
+    fprintf(opt->ulog, "-- Committed\n");
+    fflush(opt->ulog);
+
+    sql = "UPDATE ldpsystem.main SET ldp_schema_version = 12;";
+    fprintf(opt->ulog, "%s\n", sql.c_str());
+    fflush(opt->ulog);
+    opt->conn->exec(sql);
+    fprintf(opt->ulog, "-- Committed\n");
+    fflush(opt->ulog);
+}
+
+    //vector<string> tables = {
+    //    "circulation_cancellation_reasons",
+    //    "circulation_fixed_due_date_schedules",
+    //    "circulation_loan_policies",
+    //    "circulation_loans",
+    //    "circulation_loan_history",
+    //    "circulation_patron_action_sessions",
+    //    "circulation_patron_notice_policies",
+    //    "circulation_request_policies",
+    //    "circulation_requests",
+    //    "circulation_scheduled_notices",
+    //    "circulation_staff_slips",
+    //    "feesfines_accounts",
+    //    "feesfines_comments",
+    //    "feesfines_feefines",
+    //    "feesfines_feefineactions",
+    //    "feesfines_lost_item_fees_policies",
+    //    "feesfines_manualblocks",
+    //    "feesfines_overdue_fines_policies",
+    //    "feesfines_owners",
+    //    "feesfines_payments",
+    //    "feesfines_refunds",
+    //    "feesfines_transfer_criterias",
+    //    "feesfines_transfers",
+    //    "feesfines_waives",
+    //    "finance_budgets",
+    //    "finance_fiscal_years",
+    //    "finance_fund_types",
+    //    "finance_funds",
+    //    "finance_group_fund_fiscal_years",
+    //    "finance_groups",
+    //    "finance_ledgers",
+    //    "finance_transactions",
+    //    "inventory_alternative_title_types",
+    //    "inventory_call_number_types",
+    //    "inventory_classification_types",
+    //    "inventory_contributor_name_types",
+    //    "inventory_contributor_types",
+    //    "inventory_electronic_access_relationships",
+    //    "inventory_holdings_note_types",
+    //    "inventory_holdings",
+    //    "inventory_holdings_types",
+    //    "inventory_identifier_types",
+    //    "inventory_ill_policies",
+    //    "inventory_instance_formats",
+    //    "inventory_instance_note_types",
+    //    "inventory_instance_relationship_types",
+    //    "inventory_instance_statuses",
+    //    "inventory_instance_relationships",
+    //    "inventory_instances",
+    //    "inventory_instance_types",
+    //    "inventory_item_damaged_statuses",
+    //    "inventory_item_note_types",
+    //    "inventory_items",
+    //    "inventory_campuses",
+    //    "inventory_institutions",
+    //    "inventory_libraries",
+    //    "inventory_loan_types",
+    //    "inventory_locations",
+    //    "inventory_material_types",
+    //    "inventory_modes_of_issuance",
+    //    "inventory_nature_of_content_terms",
+    //    "inventory_service_points",
+    //    "inventory_service_points_users",
+    //    "inventory_statistical_code_types",
+    //    "inventory_statistical_codes",
+    //    "invoice_lines",
+    //    "invoice_invoices",
+    //    "invoice_voucher_lines",
+    //    "invoice_vouchers",
+    //    "acquisitions_memberships",
+    //    "acquisitions_units",
+    //    "po_alerts",
+    //    "po_order_invoice_relns",
+    //    "po_order_templates",
+    //    "po_pieces",
+    //    "po_lines",
+    //    "po_purchase_orders",
+    //    "po_receiving_history",
+    //    "po_reporting_codes",
+    //    "organization_addresses",
+    //    "organization_categories",
+    //    "organization_contacts",
+    //    "organization_emails",
+    //    "organization_interfaces",
+    //    "organization_organizations",
+    //    "organization_phone_numbers",
+    //    "organization_urls",
+    //    "user_groups",
+    //    "user_users"
+    //};
+
+    //{
+    //    etymon::odbc_tx tx(opt->conn);
+    //    for (auto& table : tables) {
+    //        sql =
+    //            "INSERT INTO ldpconfig.update_tables\n"
+    //            "    (enable_update, table_name, tenant_id)\n"
+    //            "    VALUES\n"
+    //            "    (TRUE, '" + table + "', 1);";
+    //        fprintf(opt->ulog, "%s\n", sql.c_str());
+    //        fflush(opt->ulog);
+    //        opt->conn->exec(sql);
+    //    }
+    //    tx.commit();
+    //    fprintf(opt->ulog, "-- Committed\n");
+    //    fflush(opt->ulog);
+    //}
+

--- a/src/dbup1.cpp
+++ b/src/dbup1.cpp
@@ -1126,6 +1126,18 @@ void database_upgrade_13(database_upgrade_options* opt)
     ulog_commit(opt);
 }
 
+void database_upgrade_14(database_upgrade_options* opt)
+{
+    dbtype dbt(opt->conn);
+
+    upgrade_add_new_table("email_email", opt, dbt);
+
+    string sql = "UPDATE ldpsystem.main SET ldp_schema_version = 14;";
+    ulog_sql(sql, opt);
+    opt->conn->exec(sql);
+    ulog_commit(opt);
+}
+
     //vector<string> tables = {
     //    "circulation_cancellation_reasons",
     //    "circulation_fixed_due_date_schedules",

--- a/src/dbup1.h
+++ b/src/dbup1.h
@@ -16,6 +16,7 @@ void database_upgrade_10(database_upgrade_options* opt);
 void database_upgrade_11(database_upgrade_options* opt);
 void database_upgrade_12(database_upgrade_options* opt);
 void database_upgrade_13(database_upgrade_options* opt);
+void database_upgrade_14(database_upgrade_options* opt);
 
 void ulog_sql(const string& sql, database_upgrade_options* opt);
 void ulog_commit(database_upgrade_options* opt);

--- a/src/dbup1.h
+++ b/src/dbup1.h
@@ -14,6 +14,7 @@ void database_upgrade_8(database_upgrade_options* opt);
 void database_upgrade_9(database_upgrade_options* opt);
 void database_upgrade_10(database_upgrade_options* opt);
 void database_upgrade_11(database_upgrade_options* opt);
+void database_upgrade_12(database_upgrade_options* opt);
 
 #endif
 

--- a/src/dbup1.h
+++ b/src/dbup1.h
@@ -15,6 +15,10 @@ void database_upgrade_9(database_upgrade_options* opt);
 void database_upgrade_10(database_upgrade_options* opt);
 void database_upgrade_11(database_upgrade_options* opt);
 void database_upgrade_12(database_upgrade_options* opt);
+void database_upgrade_13(database_upgrade_options* opt);
+
+void ulog_sql(const string& sql, database_upgrade_options* opt);
+void ulog_commit(database_upgrade_options* opt);
 
 #endif
 

--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -314,7 +314,9 @@ bool retrieve_direct(const data_source& source, ldp_log* lg,
         throw runtime_error("unable to set single-row mode in database query");
 
     string output = loadDir;
-    etymon::join(&output, table.name + "_0.json");
+    etymon::join(&output, table.name);
+    output += "_" + source.source_name;
+    output += "_0.json";
     etymon::file f(output, "w");
     ext_files->files.push_back(output);
 

--- a/src/extract.cpp
+++ b/src/extract.cpp
@@ -76,7 +76,7 @@ size_t header_callback(char* buffer, size_t size, size_t nitems,
  * okapiPassword, and okapiTenant.
  * \param[out] token The authentication token received from Okapi.
  */
-void okapi_login(const ldp_options& opt, log* lg, string* token)
+void okapi_login(const ldp_options& opt, ldp_log* lg, string* token)
 {
     //timer t(opt);
 
@@ -86,7 +86,7 @@ void okapi_login(const ldp_options& opt, log* lg, string* token)
     string path = opt.okapi_url;
     etymon::join(&path, "/authn/login");
 
-    lg->write(level::detail, "", "", "Retrieving: " + path, -1);
+    lg->write(log_level::detail, "", "", "Retrieving: " + path, -1);
 
     string tenantHeader = "X-Okapi-Tenant: ";
     tenantHeader += opt.okapi_tenant;
@@ -150,7 +150,7 @@ enum class PageStatus {
     containsRecords
 };
 
-static PageStatus retrieve(const Curl& c, const ldp_options& opt, log* lg,
+static PageStatus retrieve(const Curl& c, const ldp_options& opt, ldp_log* lg,
         const string& token, const TableSchema& table, const string& loadDir,
         extraction_files* ext_files, size_t page)
 {
@@ -188,7 +188,7 @@ static PageStatus retrieve(const Curl& c, const ldp_options& opt, log* lg,
         curl_easy_setopt(c.curl, CURLOPT_URL, path.c_str());
         curl_easy_setopt(c.curl, CURLOPT_WRITEDATA, f.fp);
 
-        lg->write(level::detail, "", "",
+        lg->write(log_level::detail, "", "",
                 "Retrieving from:\n"
                 "    Path: " + table.sourcePath + "\n"
                 "    Query: " + query, -1);
@@ -234,19 +234,19 @@ static void writeCountFile(const string& loadDir, const string& tableName,
     fputs(pageStr.c_str(), f.fp);
 }
 
-bool retrievePages(const Curl& c, const ldp_options& opt, log* lg,
+bool retrievePages(const Curl& c, const ldp_options& opt, ldp_log* lg,
         const string& token, const TableSchema& table, const string& loadDir,
         extraction_files* ext_files)
 {
     size_t page = 0;
     while (true) {
-        lg->write(level::detail, "", "",
+        lg->write(log_level::detail, "", "",
                 "Extracting page: " + to_string(page), -1);
         PageStatus status = retrieve(c, opt, lg, token, table, loadDir,
                 ext_files, page);
         switch (status) {
         case PageStatus::interfaceNotAvailable:
-            lg->write(level::trace, "", "",
+            lg->write(log_level::trace, "", "",
                     "Interface not available: " + table.sourcePath, -1);
             return false;
         case PageStatus::pageEmpty:
@@ -268,13 +268,13 @@ bool directOverride(const ldp_options& opt, const string& tableName)
     return false;
 }
 
-bool retrieveDirect(const ldp_options& opt, log* lg, const TableSchema& table,
+bool retrieveDirect(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
         const string& loadDir, extraction_files* ext_files)
 {
-    lg->write(level::trace, "", "",
+    lg->write(log_level::trace, "", "",
             "Direct from database: " + table.sourcePath, -1);
     if (table.directSourceTable == "") {
-        lg->write(level::warning, "", "",
+        lg->write(log_level::warning, "", "",
                 "Direct source table undefined: " + table.sourcePath, -1);
         return false;
     }
@@ -285,7 +285,7 @@ bool retrieveDirect(const ldp_options& opt, log* lg, const TableSchema& table,
             opt.direct.database_name, "require");
     string sql = "SELECT jsonb FROM " +
         opt.okapi_tenant + "_" + table.directSourceTable + ";";
-    lg->write(level::detail, "", "", sql, -1);
+    lg->write(log_level::detail, "", "", sql, -1);
 
     if (PQsendQuery(db.conn, sql.c_str()) == 0) {
         string err = PQerrorMessage(db.conn);

--- a/src/extract.h
+++ b/src/extract.h
@@ -2,8 +2,6 @@
 #define LDP_EXTRACT_H
 
 #include <curl/curl.h>
-#include <string>
-#include <unistd.h>
 
 #include "options.h"
 #include "schema.h"
@@ -17,22 +15,23 @@ public:
     ~extraction_files();
 };
 
-class Curl {
+class curl_wrapper {
 public:
     CURL* curl;
     struct curl_slist* headers;
-    Curl();
-    ~Curl();
+    curl_wrapper();
+    ~curl_wrapper();
 };
 
 void okapi_login(const ldp_options& o, ldp_log* lg, string* token);
 
-bool directOverride(const ldp_options& opt, const string& sourcePath);
-bool retrieveDirect(const ldp_options& opt, ldp_log* lg, const table_schema& table,
-        const string& loadDir, extraction_files* ext_files);
-bool retrievePages(const Curl& c, const ldp_options& opt, ldp_log* lg,
-        const string& token, const table_schema& table, const string& loadDir,
-        extraction_files* ext_files);
+bool direct_override(const ldp_options& opt, const string& sourcePath);
+bool retrieve_direct(const ldp_options& opt, ldp_log* lg,
+                     const table_schema& table, const string& loadDir,
+                     extraction_files* ext_files);
+bool retrieve_pages(const curl_wrapper& c, const ldp_options& opt, ldp_log* lg,
+                    const string& token, const table_schema& table,
+                    const string& loadDir, extraction_files* ext_files);
 
 #endif
 

--- a/src/extract.h
+++ b/src/extract.h
@@ -23,13 +23,15 @@ public:
     ~curl_wrapper();
 };
 
-void okapi_login(const ldp_options& o, ldp_log* lg, string* token);
+void okapi_login(const ldp_options& opt, const data_source& source,
+                 ldp_log* lg, string* token);
 
-bool direct_override(const ldp_options& opt, const string& sourcePath);
-bool retrieve_direct(const ldp_options& opt, ldp_log* lg,
+bool direct_override(const data_source& source, const string& sourcePath);
+bool retrieve_direct(const data_source& source, ldp_log* lg,
                      const table_schema& table, const string& loadDir,
                      extraction_files* ext_files);
-bool retrieve_pages(const curl_wrapper& c, const ldp_options& opt, ldp_log* lg,
+bool retrieve_pages(const curl_wrapper& c, const ldp_options& opt,
+                    const data_source& source, ldp_log* lg,
                     const string& token, const table_schema& table,
                     const string& loadDir, extraction_files* ext_files);
 

--- a/src/extract.h
+++ b/src/extract.h
@@ -28,10 +28,10 @@ public:
 void okapi_login(const ldp_options& o, ldp_log* lg, string* token);
 
 bool directOverride(const ldp_options& opt, const string& sourcePath);
-bool retrieveDirect(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
+bool retrieveDirect(const ldp_options& opt, ldp_log* lg, const table_schema& table,
         const string& loadDir, extraction_files* ext_files);
 bool retrievePages(const Curl& c, const ldp_options& opt, ldp_log* lg,
-        const string& token, const TableSchema& table, const string& loadDir,
+        const string& token, const table_schema& table, const string& loadDir,
         extraction_files* ext_files);
 
 #endif

--- a/src/extract.h
+++ b/src/extract.h
@@ -25,12 +25,12 @@ public:
     ~Curl();
 };
 
-void okapi_login(const ldp_options& o, log* lg, string* token);
+void okapi_login(const ldp_options& o, ldp_log* lg, string* token);
 
 bool directOverride(const ldp_options& opt, const string& sourcePath);
-bool retrieveDirect(const ldp_options& opt, log* lg, const TableSchema& table,
+bool retrieveDirect(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
         const string& loadDir, extraction_files* ext_files);
-bool retrievePages(const Curl& c, const ldp_options& opt, log* lg,
+bool retrievePages(const Curl& c, const ldp_options& opt, ldp_log* lg,
         const string& token, const TableSchema& table, const string& loadDir,
         extraction_files* ext_files);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -221,10 +221,8 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldpUser,
         "    detect_foreign_keys BOOLEAN NOT NULL DEFAULT FALSE,\n"
         "    force_foreign_key_constraints BOOLEAN NOT NULL DEFAULT FALSE,\n"
         "    enable_foreign_key_warnings BOOLEAN NOT NULL DEFAULT FALSE,\n"
-        "    disable_anonymization BOOLEAN NOT NULL DEFAULT TRUE\n"
+        "    disable_anonymization BOOLEAN NOT NULL DEFAULT FALSE\n"
         ");";
-    conn->exec(sql);
-    sql = "DELETE FROM ldpconfig.general;";  // Temporary: pre-LDP-1.0
     conn->exec(sql);
     sql =
         "INSERT INTO ldpconfig.general\n"
@@ -375,8 +373,8 @@ static void upgrade_database_all(etymon::odbc_conn* conn, const string& ldpUser,
         fprintf(err, "%s: Database upgrade completed\n", prog);
         fprintf(err, "%s: ", prog);
         print_banner_line(err, '=', 74);
-        log lg(conn, level::info, false, quiet, prog);
-        lg.write(level::info, "server", "", "Upgraded to database version: " +
+        ldp_log lg(conn, log_level::info, false, quiet, prog);
+        lg.write(log_level::info, "server", "", "Upgraded to database version: " +
                 to_string(latest_version), -1);
     } else {
         if (!quiet)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,7 +12,7 @@
 
 namespace fs = std::experimental::filesystem;
 
-static int64_t ldp_latest_database_version = 13;
+static int64_t ldp_latest_database_version = 14;
 
 database_upgrade_array database_upgrades[] = {
     nullptr,  // Version 0 has no migration.
@@ -28,7 +28,8 @@ database_upgrade_array database_upgrades[] = {
     database_upgrade_10,
     database_upgrade_11,
     database_upgrade_12,
-    database_upgrade_13
+    database_upgrade_13,
+    database_upgrade_14
 };
 
 int64_t latest_database_version()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -108,8 +108,8 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldpUser,
     dbtype dbt(conn);
 
     // TODO This should probably be passed into the function as a parameter.
-    Schema schema;
-    Schema::make_default_schema(&schema);
+    ldp_schema schema;
+    ldp_schema::make_default_schema(&schema);
 
     etymon::odbc_tx tx(conn);
 
@@ -159,7 +159,7 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldpUser,
 
     // Add tables to the catalog.
     for (auto& table : schema.tables)
-        catalog_add_table(conn, table.tableName);
+        catalog_add_table(conn, table.name);
 
     string rskeys;
     dbt.redshift_keys("referencing_table",
@@ -264,25 +264,25 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldpUser,
         dbt.redshift_keys("id", "id, updated", &rskeys);
         string sql =
             "CREATE TABLE IF NOT EXISTS\n"
-            "    history." + table.tableName + " (\n"
+            "    history." + table.name + " (\n"
             "    id VARCHAR(36) NOT NULL,\n"
             "    data " + dbt.json_type() + " NOT NULL,\n"
             "    updated TIMESTAMP WITH TIME ZONE NOT NULL,\n"
             "    tenant_id SMALLINT NOT NULL,\n"
             "    CONSTRAINT\n"
-            "        history_" + table.tableName + "_pkey\n"
+            "        history_" + table.name + "_pkey\n"
             "        PRIMARY KEY (id, updated)\n"
             ")" + rskeys + ";";
         conn->exec(sql);
 
         sql =
             "GRANT SELECT ON\n"
-            "    history." + table.tableName + "\n"
+            "    history." + table.name + "\n"
             "    TO " + ldpUser + ";";
         conn->exec(sql);
         sql =
             "GRANT SELECT ON\n"
-            "    history." + table.tableName + "\n"
+            "    history." + table.name + "\n"
             "    TO " + ldpconfigUser + ";";
         conn->exec(sql);
     }
@@ -293,7 +293,7 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldpUser,
         string rskeys;
         dbt.redshift_keys("id", "id", &rskeys);
         sql =
-            "CREATE TABLE " + table.tableName + " (\n"
+            "CREATE TABLE " + table.name + " (\n"
             "    id VARCHAR(65535) NOT NULL,\n"
             "    data " + dbt.json_type() + ",\n"
             "    tenant_id SMALLINT NOT NULL,\n"
@@ -301,11 +301,11 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldpUser,
         ")" + rskeys + ";";
         conn->exec(sql);
         sql =
-            "GRANT SELECT ON " + table.tableName + "\n"
+            "GRANT SELECT ON " + table.name + "\n"
             "    TO " + ldpconfigUser + ";";
         conn->exec(sql);
         sql =
-            "GRANT SELECT ON " + table.tableName + "\n"
+            "GRANT SELECT ON " + table.name + "\n"
             "    TO " + ldpUser + ";";
         conn->exec(sql);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -270,10 +270,12 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldp_user,
             "    id VARCHAR(36) NOT NULL,\n"
             "    data " + dbt.json_type() + " NOT NULL,\n"
             "    updated TIMESTAMP WITH TIME ZONE NOT NULL,\n"
-            "    tenant_id SMALLINT NOT NULL,\n"
-            "    CONSTRAINT\n"
-            "        history_" + table.name + "_pkey\n"
-            "        PRIMARY KEY (id, updated)\n"
+            // TODO Re-enable after test
+            "    tenant_id SMALLINT NOT NULL\n"
+            //"    tenant_id SMALLINT NOT NULL,\n"
+            //"    CONSTRAINT\n"
+            //"        history_" + table.name + "_pkey\n"
+            //"        PRIMARY KEY (id, updated)\n"
             ")" + rskeys + ";";
         conn->exec(sql);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -283,12 +283,10 @@ static void init_database_all(etymon::odbc_conn* conn, const string& ldp_user,
             "    id VARCHAR(36) NOT NULL,\n"
             "    data " + dbt.json_type() + " NOT NULL,\n"
             "    updated TIMESTAMP WITH TIME ZONE NOT NULL,\n"
-            // TODO Re-enable after test
-            "    tenant_id SMALLINT NOT NULL\n"
-            //"    tenant_id SMALLINT NOT NULL,\n"
-            //"    CONSTRAINT\n"
-            //"        history_" + table.name + "_pkey\n"
-            //"        PRIMARY KEY (id, updated)\n"
+            "    tenant_id SMALLINT NOT NULL,\n"
+            "    CONSTRAINT\n"
+            "        history_" + table.name + "_pkey\n"
+            "        PRIMARY KEY (id, updated)\n"
             ")" + rskeys + ";";
         conn->exec(sql);
 

--- a/src/init.h
+++ b/src/init.h
@@ -17,15 +17,16 @@ int64_t latest_database_version();
 typedef void (*database_upgrade_array)(database_upgrade_options* opt);
 
 void init_database(etymon::odbc_env* odbc, const string& dbname,
-        const string& ldpUser, const string& ldpconfigUser, FILE* err,
-        const char* prog);
+                   const string& ldp_user, const string& ldpconfig_user,
+                   FILE* err, const char* prog);
 
 void upgrade_database(etymon::odbc_env* odbc, const string& dbname,
-        const string& ldpUser, const string& ldpconfigUser,
-        const string& datadir, FILE* err, const char* prog, bool quiet);
+                      const string& ldp_user, const string& ldpconfig_user,
+                      const string& datadir, FILE* err, const char* prog,
+                      bool quiet);
 
 void validate_database_latest_version(etymon::odbc_env* odbc,
-        const string& dbname);
+                                      const string& dbname);
 
 void catalog_add_table(etymon::odbc_conn* conn, const string& table);
 

--- a/src/initutil.cpp
+++ b/src/initutil.cpp
@@ -1,0 +1,51 @@
+#include "initutil.h"
+
+void create_main_table_sql(const string& table_name, etymon::odbc_conn* conn,
+                           const dbtype& dbt, string* sql)
+{
+    string rskeys;
+    dbt.redshift_keys("id", "id", &rskeys);
+    *sql =
+        "CREATE TABLE " + table_name + " (\n"
+        "    id VARCHAR(65535) NOT NULL,\n"
+        "    data " + dbt.json_type() + ",\n"
+        "    tenant_id SMALLINT NOT NULL,\n"
+        "    PRIMARY KEY (id)\n"
+        ")" + rskeys + ";";
+}
+
+void create_history_table_sql(const string& table_name,
+                              etymon::odbc_conn* conn, const dbtype& dbt,
+                              string* sql)
+{
+    string rskeys;
+    dbt.redshift_keys("id", "id, updated", &rskeys);
+    *sql =
+        "CREATE TABLE IF NOT EXISTS\n"
+        "    history." + table_name + " (\n"
+        "    id VARCHAR(36) NOT NULL,\n"
+        "    data " + dbt.json_type() + " NOT NULL,\n"
+        "    updated TIMESTAMP WITH TIME ZONE NOT NULL,\n"
+        "    tenant_id SMALLINT NOT NULL,\n"
+        "    CONSTRAINT\n"
+        "        history_" + table_name + "_pkey\n"
+        "        PRIMARY KEY (id, updated)\n"
+        ")" + rskeys + ";";
+}
+
+void grant_select_on_table_sql(const string& table, const string& user,
+                               etymon::odbc_conn* conn, string* sql)
+{
+    *sql =
+        "GRANT SELECT ON " + table + "\n"
+        "    TO " + user + ";";
+}
+
+void add_table_to_catalog_sql(etymon::odbc_conn* conn, const string& table,
+                              string* sql)
+{
+    *sql =
+        "INSERT INTO ldpsystem.tables (table_name) VALUES\n"
+        "    ('" + table + "');";
+}
+

--- a/src/initutil.h
+++ b/src/initutil.h
@@ -1,0 +1,25 @@
+#ifndef LDP_INITUTIL_H
+#define LDP_INITUTIL_H
+
+#include <string>
+
+#include "../etymoncpp/include/odbc.h"
+#include "dbtype.h"
+
+using namespace std;
+
+void create_main_table_sql(const string& table_name, etymon::odbc_conn* conn,
+                           const dbtype& dbt, string* sql);
+
+void create_history_table_sql(const string& table_name,
+                              etymon::odbc_conn* conn, const dbtype& dbt,
+                              string* sql);
+
+void grant_select_on_table_sql(const string& table, const string& user,
+                               etymon::odbc_conn* conn, string* sql);
+
+void add_table_to_catalog_sql(etymon::odbc_conn* conn, const string& table,
+                              string* sql);
+
+#endif
+

--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -245,7 +245,7 @@ void server_loop(const ldp_options& opt, etymon::odbc_env* odbc)
             string("Server stopped") + (opt.cli_mode ? " (CLI mode)" : ""), -1);
 }
 
-void init(const ldp_options& opt)
+void cmd_init_database(const ldp_options& opt)
 {
     if (opt.set_profile == profile::none)
         throw runtime_error("Profile not specified");
@@ -257,7 +257,7 @@ void init(const ldp_options& opt)
             opt.err, opt.prog);
 }
 
-void upgrade_database(const ldp_options& opt)
+void cmd_upgrade_database(const ldp_options& opt)
 {
     etymon::odbc_env odbc;
     server_lock svrlock(&odbc, opt.db, opt.log_level, opt.err, opt.prog);
@@ -267,7 +267,7 @@ void upgrade_database(const ldp_options& opt)
             opt.err, opt.prog, opt.quiet);
 }
 
-void server(const ldp_options& opt)
+void cmd_server(const ldp_options& opt)
 {
     etymon::odbc_env odbc;
     server_lock svrlock(&odbc, opt.db, opt.log_level, opt.err, opt.prog);
@@ -385,7 +385,7 @@ void ldp_exec(ldp_options* opt)
         do {
             timer error_timer(*opt);
             try {
-                server(*opt);
+                cmd_server(*opt);
             } catch (runtime_error& e) {
                 string s = e.what();
                 if ( !(s.empty()) && s.back() == '\n' )
@@ -408,17 +408,17 @@ void ldp_exec(ldp_options* opt)
     }
 
     if (opt->command == ldp_command::update) {
-        server(*opt);
+        cmd_server(*opt);
         return;
     }
 
     if (opt->command == ldp_command::upgrade_database) {
-        upgrade_database(*opt);
+        cmd_upgrade_database(*opt);
         return;
     }
 
     if (opt->command == ldp_command::init_database) {
-        init(*opt);
+        cmd_init_database(*opt);
         return;
     }
 }

--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -276,27 +276,27 @@ void cmd_server(const ldp_options& opt)
     server_loop(opt, &odbc);
 }
 
-void config_direct_options(const ldp_config& conf, const string& base,
-        ldp_options* opt)
-{
-    int x = 0;
-    string direct_tables = base + "direct_tables/";
-    while (true) {
-        string t;
-        if (!conf.get(direct_tables + to_string(x), &t))
-            break;
-        opt->direct.table_names.push_back(t);
-        x++;
-    }
-    conf.get(base + "direct_database_name", &(opt->direct.database_name));
-    conf.get(base + "direct_database_host", &(opt->direct.database_host));
-    int port = 0;
-    conf.get_int(base + "direct_database_port", &port);
-    opt->direct.database_port = to_string(port);
-    conf.get(base + "direct_database_user", &(opt->direct.database_user));
-    conf.get(base + "direct_database_password",
-            &(opt->direct.database_password));
-}
+//void config_direct_options(const ldp_config& conf, const string& base,
+//        ldp_options* opt)
+//{
+//    int x = 0;
+//    string direct_tables = base + "direct_tables/";
+//    while (true) {
+//        string t;
+//        if (!conf.get(direct_tables + to_string(x), &t))
+//            break;
+//        opt->direct.table_names.push_back(t);
+//        x++;
+//    }
+//    conf.get(base + "direct_database_name", &(opt->direct.database_name));
+//    conf.get(base + "direct_database_host", &(opt->direct.database_host));
+//    int port = 0;
+//    conf.old_get_int(base + "direct_database_port", &port);
+//    opt->direct.database_port = to_string(port);
+//    conf.get(base + "direct_database_user", &(opt->direct.database_user));
+//    conf.get(base + "direct_database_password",
+//            &(opt->direct.database_password));
+//}
 
 void config_options(const ldp_config& conf, ldp_options* opt)
 {
@@ -309,36 +309,43 @@ void config_options(const ldp_config& conf, ldp_options* opt)
     conf.get(target + "ldpconfig_user", &(opt->ldpconfig_user));
     conf.get(target + "ldp_user", &(opt->ldp_user));
 
-    if (opt->load_from_dir == "") {
-        string enable_source;
-        conf.get_required("/enable_sources/0", &enable_source);
-        string second_source;
-        conf.get("/enable_sources/1", &second_source);
-        if (second_source != "")
-            throw runtime_error(
-                "Multiple sources not currently supported in "
-                "configuration:\n"
-                "    Attribute: enable_sources\n"
-                "    Value: " + second_source);
-        string source = "/sources/" + enable_source + "/";
-        conf.get_required(source + "okapi_url", &(opt->okapi_url));
-        conf.get_required(source + "okapi_tenant", &(opt->okapi_tenant));
-        conf.get_required(source + "okapi_user", &(opt->okapi_user));
-        conf.get_required(source + "okapi_password", &(opt->okapi_password));
+    ///////////////////////////////////////////////////////////////////////////
+    // NEW SOURCE CONFIG
+    if (opt->load_from_dir == "")
+        conf.get_enable_sources(&(opt->enable_sources));
+    ///////////////////////////////////////////////////////////////////////////
+    // OLD SOURCE CONFIG
+    //if (opt->load_from_dir == "") {
+    //    string enable_source;
+    //    conf.get_required("/enable_sources/0", &enable_source);
+    //    string second_source;
+    //    conf.get("/enable_sources/1", &second_source);
+    //    if (second_source != "")
+    //        throw runtime_error(
+    //            "Multiple sources not currently supported in "
+    //            "configuration:\n"
+    //            "    Attribute: enable_sources\n"
+    //            "    Value: " + second_source);
+    //    string source = "/sources/" + enable_source + "/";
+    //    conf.get_required(source + "okapi_url", &(opt->okapi_url));
+    //    conf.get_required(source + "okapi_tenant", &(opt->okapi_tenant));
+    //    conf.get_required(source + "okapi_user", &(opt->okapi_user));
+    //    conf.get_required(source + "okapi_password", &(opt->okapi_password));
 
-        int tenant_id = 1;
-        conf.get_int(source + "tenant_id", &tenant_id);
-        if (0 < tenant_id && tenant_id < 32768)
-            opt->tenant_id = (int16_t) tenant_id;
-        else
-            throw runtime_error(
-                "Value for configuration setting is out of range:\n"
-                "    Attribute: tenant_id\n"
-                "    Value: " + to_string(tenant_id) + "\n"
-                "    Range: 0 < tenant_id < 32768");
+    //    int tenant_id = 1;
+    //    conf.old_get_int(source + "tenant_id", &tenant_id);
+    //    if (0 < tenant_id && tenant_id < 32768)
+    //        opt->tenant_id = (int16_t) tenant_id;
+    //    else
+    //        throw runtime_error(
+    //            "Value for configuration setting is out of range:\n"
+    //            "    Attribute: tenant_id\n"
+    //            "    Value: " + to_string(tenant_id) + "\n"
+    //            "    Range: 0 < tenant_id < 32768");
 
-        config_direct_options(conf, source, opt);
-    }
+    //    config_direct_options(conf, source, opt);
+    //}
+    ///////////////////////////////////////////////////////////////////////////
 
     conf.get_bool("/disable_anonymization", &(opt->disable_anonymization));
 

--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -150,15 +150,15 @@ bool time_for_full_update(const ldp_options& opt, etymon::odbc_conn* conn,
         lg->write(log_level::error, "", "", e, -1);
         throw runtime_error(e);
     }
-    string fullUpdateEnabled, updateNow;
-    conn->get_data(&stmt, 1, &fullUpdateEnabled);
-    conn->get_data(&stmt, 2, &updateNow);
+    string full_update_enabled, update_now;
+    conn->get_data(&stmt, 1, &full_update_enabled);
+    conn->get_data(&stmt, 2, &update_now);
     if (conn->fetch(&stmt)) {
         string e = "Too many rows in table: ldpconfig.general";
         lg->write(log_level::error, "", "", e, -1);
         throw runtime_error(e);
     }
-    return fullUpdateEnabled == "1" && updateNow == "1";
+    return full_update_enabled == "1" && update_now == "1";
 }
 
 /**
@@ -170,9 +170,9 @@ bool time_for_full_update(const ldp_options& opt, etymon::odbc_conn* conn,
  * param[in] dbt
  */
 void reschedule_next_daily_load(const ldp_options& opt, etymon::odbc_conn* conn,
-        dbtype* dbt, ldp_log* lg)
+                                dbtype* dbt, ldp_log* lg)
 {
-    string updateInFuture;
+    string update_in_future;
     do {
         // Increment next_full_update.
         string sql =
@@ -193,13 +193,13 @@ void reschedule_next_daily_load(const ldp_options& opt, etymon::odbc_conn* conn,
             lg->write(log_level::error, "", "", e, -1);
             throw runtime_error(e);
         }
-        conn->get_data(&stmt, 1, &updateInFuture);
+        conn->get_data(&stmt, 1, &update_in_future);
         if (conn->fetch(&stmt)) {
             string e = "Too many rows in table: ldpconfig.general";
             lg->write(log_level::error, "", "", e, -1);
             throw runtime_error(e);
         }
-    } while (updateInFuture == "0");
+    } while (update_in_future == "0");
 }
 
 void server_loop(const ldp_options& opt, etymon::odbc_env* odbc)
@@ -280,10 +280,10 @@ void config_direct_options(const config& conf, const string& base,
         ldp_options* opt)
 {
     int x = 0;
-    string directTables = base + "direct_tables/";
+    string direct_tables = base + "direct_tables/";
     while (true) {
         string t;
-        if (!conf.get(directTables + to_string(x), &t))
+        if (!conf.get(direct_tables + to_string(x), &t))
             break;
         opt->direct.table_names.push_back(t);
         x++;
@@ -310,17 +310,17 @@ void config_options(const config& conf, ldp_options* opt)
     conf.get(target + "ldp_user", &(opt->ldp_user));
 
     if (opt->load_from_dir == "") {
-        string enableSource;
-        conf.get_required("/enable_sources/0", &enableSource);
-        string secondSource;
-        conf.get("/enable_sources/1", &secondSource);
-        if (secondSource != "")
+        string enable_source;
+        conf.get_required("/enable_sources/0", &enable_source);
+        string second_source;
+        conf.get("/enable_sources/1", &second_source);
+        if (second_source != "")
             throw runtime_error(
                     "Multiple sources not currently supported in "
                     "configuration:\n"
                     "    Attribute: enable_sources\n"
-                    "    Value: " + secondSource);
-        string source = "/sources/" + enableSource + "/";
+                    "    Value: " + second_source);
+        string source = "/sources/" + enable_source + "/";
         conf.get_required(source + "okapi_url", &(opt->okapi_url));
         conf.get_required(source + "okapi_tenant", &(opt->okapi_tenant));
         conf.get_required(source + "okapi_user", &(opt->okapi_user));
@@ -331,14 +331,6 @@ void config_options(const config& conf, ldp_options* opt)
     conf.get_bool("/disable_anonymization", &(opt->disable_anonymization));
 
     conf.get_bool("/allow_destructive_tests", &(opt->allow_destructive_tests));
-}
-
-// For LDP 1.0:
-void require_disable_anon_ldp1(const ldp_options& opt)
-{
-    if (!opt.disable_anonymization)
-        throw runtime_error(
-                "This version requires disable_anonymization in ldpconf.json");
 }
 
 void validate_options_in_deployment(const ldp_options& opt)
@@ -374,9 +366,6 @@ void ldp_exec(ldp_options* opt)
 {
     config conf(opt->datadir + "/ldpconf.json");
     config_options(conf, opt);
-
-    // For LDP 1.0:
-    // require_disable_anon_ldp1(*opt);
 
     validate_options_in_deployment(*opt);
 

--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -316,15 +316,27 @@ void config_options(const ldp_config& conf, ldp_options* opt)
         conf.get("/enable_sources/1", &second_source);
         if (second_source != "")
             throw runtime_error(
-                    "Multiple sources not currently supported in "
-                    "configuration:\n"
-                    "    Attribute: enable_sources\n"
-                    "    Value: " + second_source);
+                "Multiple sources not currently supported in "
+                "configuration:\n"
+                "    Attribute: enable_sources\n"
+                "    Value: " + second_source);
         string source = "/sources/" + enable_source + "/";
         conf.get_required(source + "okapi_url", &(opt->okapi_url));
         conf.get_required(source + "okapi_tenant", &(opt->okapi_tenant));
         conf.get_required(source + "okapi_user", &(opt->okapi_user));
         conf.get_required(source + "okapi_password", &(opt->okapi_password));
+
+        int tenant_id = 1;
+        conf.get_int(source + "tenant_id", &tenant_id);
+        if (0 < tenant_id && tenant_id < 32768)
+            opt->tenant_id = (int16_t) tenant_id;
+        else
+            throw runtime_error(
+                "Value for configuration setting is out of range:\n"
+                "    Attribute: tenant_id\n"
+                "    Value: " + to_string(tenant_id) + "\n"
+                "    Range: 0 < tenant_id < 32768");
+
         config_direct_options(conf, source, opt);
     }
 

--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -83,7 +83,6 @@ server_lock::server_lock(etymon::odbc_env* odbc, const string& db,
             conn->exec(sql);
         } catch (runtime_error& e) {
             delete tx;
-            delete conn;
             throw;
         }
     } catch (runtime_error& e) {

--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -276,7 +276,7 @@ void cmd_server(const ldp_options& opt)
     server_loop(opt, &odbc);
 }
 
-void config_direct_options(const config& conf, const string& base,
+void config_direct_options(const ldp_config& conf, const string& base,
         ldp_options* opt)
 {
     int x = 0;
@@ -298,7 +298,7 @@ void config_direct_options(const config& conf, const string& base,
             &(opt->direct.database_password));
 }
 
-void config_options(const config& conf, ldp_options* opt)
+void config_options(const ldp_config& conf, ldp_options* opt)
 {
     string deploy_env;
     conf.get_required("/deployment_environment", &deploy_env);
@@ -364,7 +364,7 @@ void validate_options_in_deployment(const ldp_options& opt)
 
 void ldp_exec(ldp_options* opt)
 {
-    config conf(opt->datadir + "/ldpconf.json");
+    ldp_config conf(opt->datadir + "/ldpconf.json");
     config_options(conf, opt);
 
     validate_options_in_deployment(*opt);
@@ -387,10 +387,11 @@ void ldp_exec(ldp_options* opt)
                     fprintf(stderr,
                             "ldp: Server error occurred after %.4f seconds\n",
                             elapsed_time);
-                    long long int waitTime = 300;
+                    long long int wait_time = 300;
                     fprintf(stderr, "ldp: Waiting for %lld seconds\n",
-                            waitTime);
-                    std::this_thread::sleep_for(std::chrono::seconds(waitTime));
+                            wait_time);
+                    std::this_thread::sleep_for(
+                        std::chrono::seconds(wait_time) );
                 }
                 fprintf(stderr, "ldp: Restarting server\n");
             }

--- a/src/ldp.h
+++ b/src/ldp.h
@@ -8,6 +8,6 @@
 int main_ldp(int argc, char* const argv[]);
 
 void ldp_exec(ldp_options* opt);
-void config_options(const config& conf, ldp_options* opt);
+void config_options(const ldp_config& conf, ldp_options* opt);
 
 #endif

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -103,15 +103,15 @@ void ldp_log::write(log_level lv, const char* type, const string& table,
     }
 
     // Log the message, and print if the log is not available.
-    string logmsgEncoded;
-    dbt->encode_string_const(logmsg.c_str(), &logmsgEncoded);
+    string logmsg_encoded;
+    dbt->encode_string_const(logmsg.c_str(), &logmsg_encoded);
     string sql =
         "INSERT INTO ldpsystem.log\n"
         "    (log_time, pid, level, type, table_name, message, elapsed_time)\n"
         "  VALUES\n"
         "    (" + string(dbt->current_timestamp()) + ", " +
         to_string(getpid()) + ", '" + level_str + "', '" + type + "', '" +
-        table + "', " + logmsgEncoded + ", " + elapsed_time_str + ");";
+        table + "', " + logmsg_encoded + ", " + elapsed_time_str + ");";
     conn->exec(sql);
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -115,14 +115,19 @@ void ldp_log::write(log_level lv, const char* type, const string& table,
     conn->exec(sql);
 }
 
+void ldp_log::warning(const string& message)
+{
+    write(log_level::warning, "", "", message, -1);
+}
+
 void ldp_log::trace(const string& message)
 {
     write(log_level::trace, "", "", message, -1);
 }
 
-void ldp_log::detail(const string& sql)
+void ldp_log::detail(const string& message)
 {
-    write(log_level::detail, "", "", sql, -1);
+    write(log_level::detail, "", "", message, -1);
 }
 
 void ldp_log::perf(const string& message, double elapsed_time)

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -5,7 +5,7 @@
 #include "../etymoncpp/include/util.h"
 #include "log.h"
 
-log::log(etymon::odbc_conn* conn, level lv, bool console, bool quiet,
+ldp_log::ldp_log(etymon::odbc_conn* conn, log_level lv, bool console, bool quiet,
         const char* program)
 {
     this->conn = conn;
@@ -16,24 +16,24 @@ log::log(etymon::odbc_conn* conn, level lv, bool console, bool quiet,
     dbt = new dbtype(conn);
 }
 
-log::~log()
+ldp_log::~ldp_log()
 {
     delete dbt;
 }
 
-void log::write(level lv, const char* type, const string& table,
+void ldp_log::write(log_level lv, const char* type, const string& table,
         const string& message, double elapsed_time)
 {
     // Add a prefix to highlight error states.
     string logmsg;
     switch (lv) {
-    case level::fatal:
+    case log_level::fatal:
         logmsg = "Fatal: " + message;
         break;
-    case level::error:
+    case log_level::error:
         logmsg = "Error: " + message;
         break;
-    case level::warning:
+    case log_level::warning:
         logmsg = "Warning: " + message;
         break;
     default:
@@ -49,7 +49,7 @@ void log::write(level lv, const char* type, const string& table,
 
     // For printing, prefix with '\n' if the message has multiple lines.
     string printmsg;
-    if (lv != level::detail && message.find('\n') != string::npos)
+    if (lv != log_level::detail && message.find('\n') != string::npos)
         printmsg = "\n" + logmsg;
     else
         printmsg = logmsg;
@@ -59,43 +59,43 @@ void log::write(level lv, const char* type, const string& table,
     // Print error states and filter messages below selected log level.
     const char* level_str;
     switch (lv) {
-    case level::fatal:
+    case log_level::fatal:
         if (!quiet)
             fprintf(stderr, "%s: %s\n", program.c_str(), printmsg.c_str());
         level_str = "fatal";
         break;
-    case level::error:
+    case log_level::error:
         if (!quiet)
             fprintf(stderr, "%s: %s\n", program.c_str(), printmsg.c_str());
         level_str = "error";
         break;
-    case level::warning:
+    case log_level::warning:
         if (!quiet)
             fprintf(stderr, "%s: %s\n", program.c_str(), printmsg.c_str());
         level_str = "warning";
         break;
-    case level::info:
+    case log_level::info:
         if (!quiet)
             fprintf(stderr, "%s: %s\n", program.c_str(), printmsg.c_str());
         level_str = "info";
         break;
-    case level::debug:
-        if (this->lv != level::debug && this->lv != level::trace &&
-                this->lv != level::detail)
+    case log_level::debug:
+        if (this->lv != log_level::debug && this->lv != log_level::trace &&
+                this->lv != log_level::detail)
             return;
         if (console && !quiet)
             fprintf(stderr, "%s\n", printmsg.c_str());
         level_str = "debug";
         break;
-    case level::trace:
-        if (this->lv != level::trace && this->lv != level::detail)
+    case log_level::trace:
+        if (this->lv != log_level::trace && this->lv != log_level::detail)
             return;
         if (console && !quiet)
             fprintf(stderr, "%s\n", printmsg.c_str());
         level_str = "trace";
         break;
-    case level::detail:
-        if (this->lv != level::detail)
+    case log_level::detail:
+        if (this->lv != log_level::detail)
             return;
         if (console && !quiet)
             fprintf(stderr, "%s\n", printmsg.c_str());
@@ -115,18 +115,18 @@ void log::write(level lv, const char* type, const string& table,
     conn->exec(sql);
 }
 
-void log::trace(const string& message)
+void ldp_log::trace(const string& message)
 {
-    write(level::trace, "", "", message, -1);
+    write(log_level::trace, "", "", message, -1);
 }
 
-void log::detail(const string& sql)
+void ldp_log::detail(const string& sql)
 {
-    write(level::detail, "", "", sql, -1);
+    write(log_level::detail, "", "", sql, -1);
 }
 
-void log::perf(const string& message, double elapsed_time)
+void ldp_log::perf(const string& message, double elapsed_time)
 {
-    write(level::debug, "perf", "", message, elapsed_time);
+    write(log_level::debug, "perf", "", message, elapsed_time);
 }
 

--- a/src/log.h
+++ b/src/log.h
@@ -26,8 +26,9 @@ public:
     ~ldp_log();
     void write(log_level lv, const char* type, const string& table,
             const string& message, double elapsed_time);
+    void warning(const string& message);
     void trace(const string& message);
-    void detail(const string& sql);
+    void detail(const string& message);
     void perf(const string& message, double elapsed_time);
 private:
     log_level lv;

--- a/src/log.h
+++ b/src/log.h
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-enum class level {
+enum class log_level {
     fatal,
     error,
     warning,
@@ -19,18 +19,18 @@ enum class level {
     detail
 };
 
-class log {
+class ldp_log {
 public:
-    log(etymon::odbc_conn* conn, level lv, bool console, bool quiet,
+    ldp_log(etymon::odbc_conn* conn, log_level lv, bool console, bool quiet,
             const char* program);
-    ~log();
-    void write(level lv, const char* type, const string& table,
+    ~ldp_log();
+    void write(log_level lv, const char* type, const string& table,
             const string& message, double elapsed_time);
     void trace(const string& message);
     void detail(const string& sql);
     void perf(const string& message, double elapsed_time);
 private:
-    level lv;
+    log_level lv;
     bool console = false;
     bool quiet = false;
     etymon::odbc_conn* conn;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <stdexcept>
-
 #include "ldp.h"
 
 int main(int argc, char* argv[])

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -4,7 +4,7 @@
 #include "names.h"
 #include "util.h"
 
-void mergeTable(const ldp_options& opt, log* lg, const TableSchema& table,
+void mergeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
         etymon::odbc_env* odbc, etymon::odbc_conn* conn, const dbtype& dbt)
 {
     // Update history tables.
@@ -28,7 +28,7 @@ void mergeTable(const ldp_options& opt, log* lg, const TableSchema& table,
         "                  h1.id = h2.id AND\n"
         "                  h1.updated < h2.updated\n"
         "      );";
-    lg->write(level::detail, "", "", sql, -1);
+    lg->write(log_level::detail, "", "", sql, -1);
     conn->exec(sql);
 
     string loadingTable;
@@ -49,11 +49,11 @@ void mergeTable(const ldp_options& opt, log* lg, const TableSchema& table,
         "    WHERE s.data IS NOT NULL AND\n"
         "          ( h.id IS NULL OR\n"
         "            (s.data)::VARCHAR <> (h.data)::VARCHAR );";
-    lg->write(level::detail, "", "", sql, -1);
+    lg->write(log_level::detail, "", "", sql, -1);
     conn->exec(sql);
 }
 
-void dropTable(const ldp_options& opt, log* lg, const string& tableName,
+void dropTable(const ldp_options& opt, ldp_log* lg, const string& tableName,
         etymon::odbc_conn* conn)
 {
     string sql = "DROP TABLE IF EXISTS " + tableName + ";";
@@ -61,7 +61,7 @@ void dropTable(const ldp_options& opt, log* lg, const string& tableName,
     conn->exec(sql);
 }
 
-void placeTable(const ldp_options& opt, log* lg, const TableSchema& table,
+void placeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
         etymon::odbc_conn* conn)
 {
     string loadingTable;
@@ -69,7 +69,7 @@ void placeTable(const ldp_options& opt, log* lg, const TableSchema& table,
     string sql =
         "ALTER TABLE " + loadingTable + "\n"
         "    RENAME TO " + table.tableName + ";";
-    lg->write(level::detail, "", "", sql, -1);
+    lg->write(log_level::detail, "", "", sql, -1);
     conn->exec(sql);
 }
 

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -4,16 +4,16 @@
 #include "names.h"
 #include "util.h"
 
-void mergeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
+void mergeTable(const ldp_options& opt, ldp_log* lg, const table_schema& table,
         etymon::odbc_env* odbc, etymon::odbc_conn* conn, const dbtype& dbt)
 {
     // Update history tables.
 
     string historyTable;
-    historyTableName(table.tableName, &historyTable);
+    historyTableName(table.name, &historyTable);
 
     string latestHistoryTable;
-    latestHistoryTableName(table.tableName, &latestHistoryTable);
+    latestHistoryTableName(table.name, &latestHistoryTable);
 
     string sql =
         "CREATE TEMPORARY TABLE\n"
@@ -32,7 +32,7 @@ void mergeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
     conn->exec(sql);
 
     string loadingTable;
-    loadingTableName(table.tableName, &loadingTable);
+    loadingTableName(table.name, &loadingTable);
 
     sql =
         "INSERT INTO " + historyTable + "\n"
@@ -61,14 +61,14 @@ void dropTable(const ldp_options& opt, ldp_log* lg, const string& tableName,
     conn->exec(sql);
 }
 
-void placeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
+void placeTable(const ldp_options& opt, ldp_log* lg, const table_schema& table,
         etymon::odbc_conn* conn)
 {
     string loadingTable;
-    loadingTableName(table.tableName, &loadingTable);
+    loadingTableName(table.name, &loadingTable);
     string sql =
         "ALTER TABLE " + loadingTable + "\n"
-        "    RENAME TO " + table.tableName + ";";
+        "    RENAME TO " + table.name + ";";
     lg->write(log_level::detail, "", "", sql, -1);
     conn->exec(sql);
 }

--- a/src/merge.h
+++ b/src/merge.h
@@ -9,13 +9,13 @@
 
 using namespace std;
 
-void mergeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
+void mergeTable(const ldp_options& opt, ldp_log* lg, const table_schema& table,
         etymon::odbc_env* odbc, etymon::odbc_conn* conn, const dbtype& dbt);
 void dropTable(const ldp_options& opt, ldp_log* lg, const string& tableName,
         etymon::odbc_conn* conn);
-void placeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
+void placeTable(const ldp_options& opt, ldp_log* lg, const table_schema& table,
         etymon::odbc_conn* conn);
-void updateStatus(const ldp_options& opt, const TableSchema& table,
+void updateStatus(const ldp_options& opt, const table_schema& table,
         etymon::odbc_conn* conn);
 
 #endif

--- a/src/merge.h
+++ b/src/merge.h
@@ -9,11 +9,11 @@
 
 using namespace std;
 
-void mergeTable(const ldp_options& opt, log* lg, const TableSchema& table,
+void mergeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
         etymon::odbc_env* odbc, etymon::odbc_conn* conn, const dbtype& dbt);
-void dropTable(const ldp_options& opt, log* lg, const string& tableName,
+void dropTable(const ldp_options& opt, ldp_log* lg, const string& tableName,
         etymon::odbc_conn* conn);
-void placeTable(const ldp_options& opt, log* lg, const TableSchema& table,
+void placeTable(const ldp_options& opt, ldp_log* lg, const TableSchema& table,
         etymon::odbc_conn* conn);
 void updateStatus(const ldp_options& opt, const TableSchema& table,
         etymon::odbc_conn* conn);

--- a/src/merge.h
+++ b/src/merge.h
@@ -9,13 +9,12 @@
 
 using namespace std;
 
-void mergeTable(const ldp_options& opt, ldp_log* lg, const table_schema& table,
-        etymon::odbc_env* odbc, etymon::odbc_conn* conn, const dbtype& dbt);
-void dropTable(const ldp_options& opt, ldp_log* lg, const string& tableName,
-        etymon::odbc_conn* conn);
-void placeTable(const ldp_options& opt, ldp_log* lg, const table_schema& table,
-        etymon::odbc_conn* conn);
-void updateStatus(const ldp_options& opt, const table_schema& table,
-        etymon::odbc_conn* conn);
+void merge_table(const ldp_options& opt, ldp_log* lg, const table_schema& table,
+                 etymon::odbc_env* odbc, etymon::odbc_conn* conn,
+                 const dbtype& dbt);
+void drop_table(const ldp_options& opt, ldp_log* lg, const string& tableName,
+                etymon::odbc_conn* conn);
+void place_table(const ldp_options& opt, ldp_log* lg, const table_schema& table,
+                 etymon::odbc_conn* conn);
 
 #endif

--- a/src/names.cpp
+++ b/src/names.cpp
@@ -1,16 +1,16 @@
 #include "names.h"
 
-void loadingTableName(const string& table, string* newtable)
+void loading_table_name(const string& table, string* newtable)
 {
     *newtable = "ldp_" + table;
 }
 
-void latestHistoryTableName(const string& table, string* newtable)
+void latest_history_table_name(const string& table, string* newtable)
 {
     *newtable = "history_latest_" + table;
 }
 
-void historyTableName(const string& table, string* newtable)
+void history_table_name(const string& table, string* newtable)
 {
     *newtable = "history." + table;
 }

--- a/src/names.h
+++ b/src/names.h
@@ -5,9 +5,9 @@
 
 using namespace std;
 
-void loadingTableName(const string& table, string* newtable);
-void latestHistoryTableName(const string& table, string* newtable);
-void historyTableName(const string& table, string* newtable);
+void loading_table_name(const string& table, string* newtable);
+void latest_history_table_name(const string& table, string* newtable);
+void history_table_name(const string& table, string* newtable);
 
 #endif
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -38,6 +38,10 @@ static void evaloptlong(char* name, char* arg, ldp_options* opt)
         config_set_profile(arg, &(opt->set_profile));
         return;
     }
+    if (!strcmp(name, "no-update")) {
+        opt->no_update = true;
+        return;
+    }
     if (!strcmp(name, "savetemps")) {
         opt->savetemps = true;
         return;
@@ -96,6 +100,7 @@ int evalopt(const etymon::command_args& cargs, ldp_options *opt)
         { "debug",        no_argument,       NULL, 0   },
         { "detail",       no_argument,       NULL, 0   },
         { "extract-only", no_argument,       NULL, 0   },
+        { "no-update",    no_argument,       NULL, 0   },
         { "profile",      required_argument, NULL, 0   },
         { "quiet",        no_argument,       NULL, 0   },
         { "sourcedir",    required_argument, NULL, 0   },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -46,11 +46,11 @@ static void evaloptlong(char* name, char* arg, ldp_options* opt)
         return;
     }
     if (!strcmp(name, "trace")) {
-        opt->log_level = level::trace;
+        opt->lg_level = log_level::trace;
         return;
     }
     if (!strcmp(name, "detail")) {
-        opt->log_level = level::detail;
+        opt->lg_level = log_level::detail;
         return;
     }
     if (!strcmp(name, "console")) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,8 +1,9 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <getopt.h>
 #include <stdexcept>
+
 #include "options.h"
 #include "err.h"
 

--- a/src/options.h
+++ b/src/options.h
@@ -52,6 +52,7 @@ public:
     string okapi_tenant;
     string okapi_user;
     string okapi_password;
+    int16_t tenant_id = 1;
     direct_extraction direct;
     deployment_environment deploy_env;
     string db;

--- a/src/options.h
+++ b/src/options.h
@@ -1,7 +1,9 @@
 #ifndef LDP_OPTIONS_H
 #define LDP_OPTIONS_H
 
+#include <map>
 #include <string>
+#include <vector>
 
 #include "../etymoncpp/include/util.h"
 #include "dbtype.h"
@@ -39,6 +41,17 @@ public:
     string database_password;
 };
 
+class data_source {
+public:
+    string source_name;
+    string okapi_url;
+    string okapi_tenant;
+    string okapi_user;
+    string okapi_password;
+    int16_t tenant_id = 1;
+    direct_extraction direct;
+};
+
 class ldp_options {
 public:
     ldp_command command;
@@ -47,13 +60,19 @@ public:
     string datadir;
     bool extract_only = false;
     string load_from_dir;
-    string source;
-    string okapi_url;
-    string okapi_tenant;
-    string okapi_user;
-    string okapi_password;
-    int16_t tenant_id = 1;
-    direct_extraction direct;
+    ///////////////////////////////////////////////////////////////////////////
+    // NEW SOURCE CONFIG
+    vector<data_source> enable_sources;
+    ///////////////////////////////////////////////////////////////////////////
+    // OLD SOURCE CONFIG
+    //string source;
+    //string okapi_url;
+    //string okapi_tenant;
+    //string okapi_user;
+    //string okapi_password;
+    //int16_t tenant_id = 1;
+    //direct_extraction direct;
+    ///////////////////////////////////////////////////////////////////////////
     deployment_environment deploy_env;
     string db;
     string ldp_user = "ldp";

--- a/src/options.h
+++ b/src/options.h
@@ -64,7 +64,7 @@ public:
     FILE* err = stderr;
     bool verbose = false;  // Deprecated.
     bool debug = false;  // Deprecated.
-    level log_level = level::debug;
+    log_level lg_level = log_level::debug;
     bool console = false;
     bool quiet = false;
     size_t page_size = 1000;

--- a/src/options.h
+++ b/src/options.h
@@ -56,6 +56,7 @@ class ldp_options {
 public:
     ldp_command command;
     profile set_profile = profile::none;
+    bool no_update = false;
     bool cli_mode = false;
     string datadir;
     bool extract_only = false;

--- a/src/paging.cpp
+++ b/src/paging.cpp
@@ -25,7 +25,7 @@ class PagingJSONHandler :
     public json::BaseReaderHandler<json::UTF8<>, PagingJSONHandler> {
 public:
     int level = 0;
-    bool foundRecord = false;
+    bool found_record = false;
     const ldp_options& opt;
     PagingJSONHandler(const ldp_options& options) : opt(options) { }
     bool StartObject();
@@ -46,7 +46,7 @@ public:
 bool PagingJSONHandler::StartObject()
 {
     if (level == 2) {
-        foundRecord = true;
+        found_record = true;
         return false;
     }
     level++;
@@ -117,14 +117,14 @@ bool PagingJSONHandler::Null()
     return true;
 }
 
-bool pageIsEmpty(const ldp_options& opt, const string& filename)
+bool page_is_empty(const ldp_options& opt, const string& filename)
 {
     PagingJSONHandler handler(opt);
     json::Reader reader;
-    char readBuffer[65536];
+    char read_buffer[65536];
     etymon::file f(filename, "r");
-    json::FileReadStream is(f.fp, readBuffer, sizeof(readBuffer));
+    json::FileReadStream is(f.fp, read_buffer, sizeof read_buffer);
     reader.Parse(is, handler);
-    return !(handler.foundRecord);
+    return !(handler.found_record);
 }
 

--- a/src/paging.h
+++ b/src/paging.h
@@ -1,10 +1,7 @@
 #ifndef LDP_PAGING_H
 #define LDP_PAGING_H
 
-#include <string>
-
-using namespace std;
-
-bool pageIsEmpty(const ldp_options& opt, const string& filename);
+bool page_is_empty(const ldp_options& opt, const string& filename);
 
 #endif
+

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -534,13 +534,13 @@ void ColumnSchema::columnTypeToString(ColumnType type, string* str)
     }
 }
 
-bool ColumnSchema::selectColumnType(log* lg, const string& table,
+bool ColumnSchema::selectColumnType(ldp_log* lg, const string& table,
         const string& source_path, const string& field, const Counts& counts,
         ColumnType* ctype)
 {
     // Check for incompatible types.
     if (counts.string > 0 && counts.number > 0) {
-        lg->write(level::error, "", "",
+        lg->write(log_level::error, "", "",
                 "Inconsistent data types in source data:\n"
                 "    Table: " + table + "\n"
                 "    Source path: " + source_path + "\n"

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -2,20 +2,20 @@
 
 #include "schema.h"
 
-void Schema::make_default_schema(Schema* schema)
+void ldp_schema::make_default_schema(ldp_schema* schema)
 {
     schema->tables.clear();
 
-    TableSchema table;
+    table_schema table;
 
-    table.sourceType = SourceType::rmb;
+    table.source_type = data_source_type::rmb;
     table.anonymize = false;
 
     ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-circulation-storage";
+    table.module_name = "mod-circulation-storage";
 
-    table.sourcePath = "/cancellation-reason-storage/cancellation-reasons";
-    table.tableName = "circulation_cancellation_reasons";
+    table.source_spec = "/cancellation-reason-storage/cancellation-reasons";
+    table.name = "circulation_cancellation_reasons";
     schema->tables.push_back(table);
 
     // TODO This seems to use a different json format.
@@ -33,500 +33,500 @@ void Schema::make_default_schema(Schema* schema)
     //     122b3d2b-4788-4f1e-9117-56daa91cb75c o
     //     15bb6216-8198-42da-bdd7-4b1e6dfb27ff "
     // }
-    table.sourcePath = "/circulation-rules-storage";
-    //table.tableName = "";
+    table.source_spec = "/circulation-rules-storage";
+    //table.name = "";
     // schema->tables.push_back(table);
 
-    table.sourcePath =
+    table.source_spec =
         "/fixed-due-date-schedule-storage/fixed-due-date-schedules";
-    table.tableName = "circulation_fixed_due_date_schedules";
+    table.name = "circulation_fixed_due_date_schedules";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/loan-policy-storage/loan-policies";
-    table.tableName = "circulation_loan_policies";
+    table.source_spec = "/loan-policy-storage/loan-policies";
+    table.name = "circulation_loan_policies";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/loan-storage/loans";
-    table.tableName = "circulation_loans";
+    table.source_spec = "/loan-storage/loans";
+    table.name = "circulation_loans";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/loan-storage/loan-history";
-    table.tableName = "circulation_loan_history";
+    table.source_spec = "/loan-storage/loan-history";
+    table.name = "circulation_loan_history";
     schema->tables.push_back(table);
 
     // okapi returns 422 Unprocessable Entity
-    table.sourcePath =
+    table.source_spec =
         "/patron-action-session-storage/expired-session-patron-ids";
-    //table.tableName = "";
+    //table.name = "";
     // schema->tables.push_back(table);
 
-    table.sourcePath = "/patron-action-session-storage/patron-action-sessions";
-    table.tableName = "circulation_patron_action_sessions";
+    table.source_spec = "/patron-action-session-storage/patron-action-sessions";
+    table.name = "circulation_patron_action_sessions";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/patron-notice-policy-storage/patron-notice-policies";
-    table.tableName = "circulation_patron_notice_policies";
+    table.source_spec = "/patron-notice-policy-storage/patron-notice-policies";
+    table.name = "circulation_patron_notice_policies";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/request-policy-storage/request-policies";
-    table.tableName = "circulation_request_policies";
+    table.source_spec = "/request-policy-storage/request-policies";
+    table.name = "circulation_request_policies";
     schema->tables.push_back(table);
 
     // Removed for lack of data
-    //table.sourcePath = "/request-preference-storage/request-preference";
-    //table.tableName = "circulation_request_preference";
+    //table.source_spec = "/request-preference-storage/request-preference";
+    //table.name = "circulation_request_preference";
     //schema->tables.push_back(table);
 
-    table.sourcePath = "/request-storage/requests";
-    table.tableName = "circulation_requests";
+    table.source_spec = "/request-storage/requests";
+    table.name = "circulation_requests";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/scheduled-notice-storage/scheduled-notices";
-    table.tableName = "circulation_scheduled_notices";
+    table.source_spec = "/scheduled-notice-storage/scheduled-notices";
+    table.name = "circulation_scheduled_notices";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/staff-slips-storage/staff-slips";
-    table.tableName = "circulation_staff_slips";
+    table.source_spec = "/staff-slips-storage/staff-slips";
+    table.name = "circulation_staff_slips";
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-feesfines";
+    table.module_name = "mod-feesfines";
 
-    table.sourcePath = "/accounts";
-    table.tableName = "feesfines_accounts";
+    table.source_spec = "/accounts";
+    table.name = "feesfines_accounts";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/comments";
-    table.tableName = "feesfines_comments";
+    table.source_spec = "/comments";
+    table.name = "feesfines_comments";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/feefines";
-    table.tableName = "feesfines_feefines";
+    table.source_spec = "/feefines";
+    table.name = "feesfines_feefines";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/feefineactions";
-    table.tableName = "feesfines_feefineactions";
+    table.source_spec = "/feefineactions";
+    table.name = "feesfines_feefineactions";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/lost-item-fees-policies";
-    table.tableName = "feesfines_lost_item_fees_policies";
+    table.source_spec = "/lost-item-fees-policies";
+    table.name = "feesfines_lost_item_fees_policies";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/manualblocks";
-    table.tableName = "feesfines_manualblocks";
+    table.source_spec = "/manualblocks";
+    table.name = "feesfines_manualblocks";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/overdue-fines-policies";
-    table.tableName = "feesfines_overdue_fines_policies";
+    table.source_spec = "/overdue-fines-policies";
+    table.name = "feesfines_overdue_fines_policies";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/owners";
-    table.tableName = "feesfines_owners";
+    table.source_spec = "/owners";
+    table.name = "feesfines_owners";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/payments";
-    table.tableName = "feesfines_payments";
+    table.source_spec = "/payments";
+    table.name = "feesfines_payments";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/refunds";
-    table.tableName = "feesfines_refunds";
+    table.source_spec = "/refunds";
+    table.name = "feesfines_refunds";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/transfer-criterias";
-    table.tableName = "feesfines_transfer_criterias";
+    table.source_spec = "/transfer-criterias";
+    table.name = "feesfines_transfer_criterias";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/transfers";
-    table.tableName = "feesfines_transfers";
+    table.source_spec = "/transfers";
+    table.name = "feesfines_transfers";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/waives";
-    table.tableName = "feesfines_waives";
+    table.source_spec = "/waives";
+    table.name = "feesfines_waives";
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
 /*
-    table.moduleName = "mod-courses";
+    table.module_name = "mod-courses";
 
-    table.sourcePath = "/coursereserves/courselistings";
-    table.tableName = "course_courselistings";
+    table.source_spec = "/coursereserves/courselistings";
+    table.name = "course_courselistings";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/roles";
-    table.tableName = "course_roles";
+    table.source_spec = "/coursereserves/roles";
+    table.name = "course_roles";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/terms";
-    table.tableName = "course_terms";
+    table.source_spec = "/coursereserves/terms";
+    table.name = "course_terms";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/coursetypes";
-    table.tableName = "course_coursetypes";
+    table.source_spec = "/coursereserves/coursetypes";
+    table.name = "course_coursetypes";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/departments";
-    table.tableName = "course_departments";
+    table.source_spec = "/coursereserves/departments";
+    table.name = "course_departments";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/processingstatuses";
-    table.tableName = "course_processingstatuses";
+    table.source_spec = "/coursereserves/processingstatuses";
+    table.name = "course_processingstatuses";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/copyrightstatuses";
-    table.tableName = "course_copyrightstatuses";
+    table.source_spec = "/coursereserves/copyrightstatuses";
+    table.name = "course_copyrightstatuses";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/courses";
-    table.tableName = "course_courses";
+    table.source_spec = "/coursereserves/courses";
+    table.name = "course_courses";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/coursereserves/reserves";
-    table.tableName = "course_reserves";
+    table.source_spec = "/coursereserves/reserves";
+    table.name = "course_reserves";
     schema->tables.push_back(table);
 */
 
     ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-finance-storage";
+    table.module_name = "mod-finance-storage";
 
-    table.sourcePath = "/finance-storage/budgets";
-    table.tableName = "finance_budgets";
+    table.source_spec = "/finance-storage/budgets";
+    table.name = "finance_budgets";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/finance-storage/fiscal-years";
-    table.tableName = "finance_fiscal_years";
-    schema->tables.push_back(table);
-
-    // Removed for lack of data
-    //table.sourcePath = "/finance-storage/fund-distributions";
-    //table.tableName = "finance_fund_distributions";
-    //schema->tables.push_back(table);
-
-    table.sourcePath = "/finance-storage/fund-types";
-    table.tableName = "finance_fund_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/finance-storage/funds";
-    table.tableName = "finance_funds";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/finance-storage/group-fund-fiscal-years";
-    table.tableName = "finance_group_fund_fiscal_years";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/finance-storage/groups";
-    table.tableName = "finance_groups";
+    table.source_spec = "/finance-storage/fiscal-years";
+    table.name = "finance_fiscal_years";
     schema->tables.push_back(table);
 
     // Removed for lack of data
-    //table.sourcePath = "/finance-storage/ledger-fiscal-years";
-    //table.tableName = "finance_ledger_fiscal_years";
+    //table.source_spec = "/finance-storage/fund-distributions";
+    //table.name = "finance_fund_distributions";
     //schema->tables.push_back(table);
 
-    table.sourcePath = "/finance-storage/ledgers";
-    table.tableName = "finance_ledgers";
+    table.source_spec = "/finance-storage/fund-types";
+    table.name = "finance_fund_types";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/finance-storage/transactions";
-    table.tableName = "finance_transactions";
+    table.source_spec = "/finance-storage/funds";
+    table.name = "finance_funds";
     schema->tables.push_back(table);
 
-    ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-inventory-storage";
-
-    table.sourcePath = "/alternative-title-types";
-    table.tableName = "inventory_alternative_title_types";
+    table.source_spec = "/finance-storage/group-fund-fiscal-years";
+    table.name = "finance_group_fund_fiscal_years";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/call-number-types";
-    table.tableName = "inventory_call_number_types";
+    table.source_spec = "/finance-storage/groups";
+    table.name = "finance_groups";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/classification-types";
-    table.tableName = "inventory_classification_types";
+    // Removed for lack of data
+    //table.source_spec = "/finance-storage/ledger-fiscal-years";
+    //table.name = "finance_ledger_fiscal_years";
+    //schema->tables.push_back(table);
+
+    table.source_spec = "/finance-storage/ledgers";
+    table.name = "finance_ledgers";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/contributor-name-types";
-    table.tableName = "inventory_contributor_name_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/contributor-types";
-    table.tableName = "inventory_contributor_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/electronic-access-relationships";
-    table.tableName = "inventory_electronic_access_relationships";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/holdings-note-types";
-    table.tableName = "inventory_holdings_note_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/holdings-storage/holdings";
-    table.directSourceTable = "mod_inventory_storage.holdings_record";
-    table.tableName = "inventory_holdings";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/holdings-types";
-    table.tableName = "inventory_holdings_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/identifier-types";
-    table.tableName = "inventory_identifier_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/ill-policies";
-    table.tableName = "inventory_ill_policies";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-formats";
-    table.tableName = "inventory_instance_formats";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-note-types";
-    table.tableName = "inventory_instance_note_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-relationship-types";
-    table.tableName = "inventory_instance_relationship_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-statuses";
-    table.tableName = "inventory_instance_statuses";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-storage/instance-relationships";
-    table.tableName = "inventory_instance_relationships";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-storage/instances";
-    table.directSourceTable = "mod_inventory_storage.instance";
-    table.tableName = "inventory_instances";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/instance-types";
-    table.tableName = "inventory_instance_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/item-damaged-statuses";
-    table.tableName = "inventory_item_damaged_statuses";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/item-note-types";
-    table.tableName = "inventory_item_note_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/item-storage/items";
-    table.directSourceTable = "mod_inventory_storage.item";
-    table.tableName = "inventory_items";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/location-units/campuses";
-    table.tableName = "inventory_campuses";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/location-units/institutions";
-    table.tableName = "inventory_institutions";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/location-units/libraries";
-    table.tableName = "inventory_libraries";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/loan-types";
-    table.tableName = "inventory_loan_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/locations";
-    table.tableName = "inventory_locations";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/material-types";
-    table.tableName = "inventory_material_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/modes-of-issuance";
-    table.tableName = "inventory_modes_of_issuance";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/nature-of-content-terms";
-    table.tableName = "inventory_nature_of_content_terms";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/service-points";
-    table.tableName = "inventory_service_points";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/service-points-users";
-    table.tableName = "inventory_service_points_users";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/statistical-code-types";
-    table.tableName = "inventory_statistical_code_types";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/statistical-codes";
-    table.tableName = "inventory_statistical_codes";
+    table.source_spec = "/finance-storage/transactions";
+    table.name = "finance_transactions";
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-invoice-storage";
+    table.module_name = "mod-inventory-storage";
+
+    table.source_spec = "/alternative-title-types";
+    table.name = "inventory_alternative_title_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/call-number-types";
+    table.name = "inventory_call_number_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/classification-types";
+    table.name = "inventory_classification_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/contributor-name-types";
+    table.name = "inventory_contributor_name_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/contributor-types";
+    table.name = "inventory_contributor_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/electronic-access-relationships";
+    table.name = "inventory_electronic_access_relationships";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/holdings-note-types";
+    table.name = "inventory_holdings_note_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/holdings-storage/holdings";
+    table.direct_source_table = "mod_inventory_storage.holdings_record";
+    table.name = "inventory_holdings";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/holdings-types";
+    table.name = "inventory_holdings_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/identifier-types";
+    table.name = "inventory_identifier_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/ill-policies";
+    table.name = "inventory_ill_policies";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-formats";
+    table.name = "inventory_instance_formats";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-note-types";
+    table.name = "inventory_instance_note_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-relationship-types";
+    table.name = "inventory_instance_relationship_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-statuses";
+    table.name = "inventory_instance_statuses";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-storage/instance-relationships";
+    table.name = "inventory_instance_relationships";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-storage/instances";
+    table.direct_source_table = "mod_inventory_storage.instance";
+    table.name = "inventory_instances";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/instance-types";
+    table.name = "inventory_instance_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/item-damaged-statuses";
+    table.name = "inventory_item_damaged_statuses";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/item-note-types";
+    table.name = "inventory_item_note_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/item-storage/items";
+    table.direct_source_table = "mod_inventory_storage.item";
+    table.name = "inventory_items";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/location-units/campuses";
+    table.name = "inventory_campuses";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/location-units/institutions";
+    table.name = "inventory_institutions";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/location-units/libraries";
+    table.name = "inventory_libraries";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/loan-types";
+    table.name = "inventory_loan_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/locations";
+    table.name = "inventory_locations";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/material-types";
+    table.name = "inventory_material_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/modes-of-issuance";
+    table.name = "inventory_modes_of_issuance";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/nature-of-content-terms";
+    table.name = "inventory_nature_of_content_terms";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/service-points";
+    table.name = "inventory_service_points";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/service-points-users";
+    table.name = "inventory_service_points_users";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/statistical-code-types";
+    table.name = "inventory_statistical_code_types";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/statistical-codes";
+    table.name = "inventory_statistical_codes";
+    schema->tables.push_back(table);
+
+    ///////////////////////////////////////////////////////////////////////////
+    table.module_name = "mod-invoice-storage";
 
     // okapi returns 400 Bad Request
-    //table.sourcePath = "/invoice-storage/invoice-line-number";
-    //table.tableName = "invoice_line_number";
+    //table.source_spec = "/invoice-storage/invoice-line-number";
+    //table.name = "invoice_line_number";
     //schema->tables.push_back(table);
 
-    table.sourcePath = "/invoice-storage/invoice-lines";
-    table.tableName = "invoice_lines";
+    table.source_spec = "/invoice-storage/invoice-lines";
+    table.name = "invoice_lines";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/invoice-storage/invoices";
-    table.tableName = "invoice_invoices";
+    table.source_spec = "/invoice-storage/invoices";
+    table.name = "invoice_invoices";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/voucher-storage/voucher-lines";
-    table.tableName = "invoice_voucher_lines";
+    table.source_spec = "/voucher-storage/voucher-lines";
+    table.name = "invoice_voucher_lines";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/voucher-storage/vouchers";
-    table.tableName = "invoice_vouchers";
+    table.source_spec = "/voucher-storage/vouchers";
+    table.name = "invoice_vouchers";
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-orders-storage";
+    table.module_name = "mod-orders-storage";
 
-    table.sourcePath = "/acquisitions-units-storage/memberships";
-    table.tableName = "acquisitions_memberships";
+    table.source_spec = "/acquisitions-units-storage/memberships";
+    table.name = "acquisitions_memberships";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/acquisitions-units-storage/units";
-    table.tableName = "acquisitions_units";
+    table.source_spec = "/acquisitions-units-storage/units";
+    table.name = "acquisitions_units";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/alerts";
-    table.tableName = "po_alerts";
+    table.source_spec = "/orders-storage/alerts";
+    table.name = "po_alerts";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/order-invoice-relns";
-    table.tableName = "po_order_invoice_relns";
+    table.source_spec = "/orders-storage/order-invoice-relns";
+    table.name = "po_order_invoice_relns";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/order-templates";
-    table.tableName = "po_order_templates";
+    table.source_spec = "/orders-storage/order-templates";
+    table.name = "po_order_templates";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/pieces";
-    table.tableName = "po_pieces";
+    table.source_spec = "/orders-storage/pieces";
+    table.name = "po_pieces";
     schema->tables.push_back(table);
 
     // okapi returns 400 Bad Request
-    //table.sourcePath = "/orders-storage/po-line-number";
-    //table.tableName = "";
+    //table.source_spec = "/orders-storage/po-line-number";
+    //table.name = "";
     //schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/po-lines";
-    table.tableName = "po_lines";
+    table.source_spec = "/orders-storage/po-lines";
+    table.name = "po_lines";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/purchase-orders";
-    table.tableName = "po_purchase_orders";
+    table.source_spec = "/orders-storage/purchase-orders";
+    table.name = "po_purchase_orders";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/receiving-history";
-    table.tableName = "po_receiving_history";
+    table.source_spec = "/orders-storage/receiving-history";
+    table.name = "po_receiving_history";
     schema->tables.push_back(table);
 
-    table.sourcePath = "/orders-storage/reporting-codes";
-    table.tableName = "po_reporting_codes";
-    schema->tables.push_back(table);
-
-    ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-organizations-storage";
-
-    table.sourcePath = "/organizations-storage/addresses";
-    table.tableName = "organization_addresses";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/categories";
-    table.tableName = "organization_categories";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/contacts";
-    table.tableName = "organization_contacts";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/emails";
-    table.tableName = "organization_emails";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/interfaces";
-    table.tableName = "organization_interfaces";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/organizations";
-    table.tableName = "organization_organizations";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/phone-numbers";
-    table.tableName = "organization_phone_numbers";
-    schema->tables.push_back(table);
-
-    table.sourcePath = "/organizations-storage/urls";
-    table.tableName = "organization_urls";
+    table.source_spec = "/orders-storage/reporting-codes";
+    table.name = "po_reporting_codes";
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
-    //table.moduleName = "mod-source-record-storage";
+    table.module_name = "mod-organizations-storage";
 
-    //table.sourceType = SourceType::rmbMarc;
-    //table.sourcePath = "/source-storage/records";
-    //table.tableName = "srs_source_records";
+    table.source_spec = "/organizations-storage/addresses";
+    table.name = "organization_addresses";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/categories";
+    table.name = "organization_categories";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/contacts";
+    table.name = "organization_contacts";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/emails";
+    table.name = "organization_emails";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/interfaces";
+    table.name = "organization_interfaces";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/organizations";
+    table.name = "organization_organizations";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/phone-numbers";
+    table.name = "organization_phone_numbers";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/organizations-storage/urls";
+    table.name = "organization_urls";
+    schema->tables.push_back(table);
+
+    ///////////////////////////////////////////////////////////////////////////
+    //table.module_name = "mod-source-record-storage";
+
+    //table.source_type = data_source_type::rmb_marc;
+    //table.source_spec = "/source-storage/records";
+    //table.name = "srs_source_records";
     //schema->tables.push_back(table);
-    //table.sourceType = SourceType::rmb;
+    //table.source_type = data_source_type::rmb;
 
     ///////////////////////////////////////////////////////////////////////////
-    table.moduleName = "mod-users";
+    table.module_name = "mod-users";
 
     // Removed for lack of data
-    //table.sourcePath = "/addresstypes";
-    //table.tableName = "user_addresstypes";
+    //table.source_spec = "/addresstypes";
+    //table.name = "user_addresstypes";
     //schema->tables.push_back(table);
 
-    table.sourcePath = "/groups";
-    table.tableName = "user_groups";
+    table.source_spec = "/groups";
+    table.name = "user_groups";
     schema->tables.push_back(table);
 
     // Removed for lack of data
-    //table.sourcePath = "/proxiesfor";
-    //table.tableName = "user_proxiesfor";
+    //table.source_spec = "/proxiesfor";
+    //table.name = "user_proxiesfor";
     //schema->tables.push_back(table);
 
-    table.sourcePath = "/users";
-    table.tableName = "user_users";
+    table.source_spec = "/users";
+    table.name = "user_users";
     table.anonymize = true;
     schema->tables.push_back(table);
     table.anonymize = false;
 }
 
-void ColumnSchema::columnTypeToString(ColumnType type, string* str)
+void column_schema::type_to_string(column_type type, string* str)
 {
     switch (type) {
-    case ColumnType::bigint:
+    case column_type::bigint:
         *str = "BIGINT";
         break;
-    case ColumnType::boolean:
+    case column_type::boolean:
         *str = "BOOLEAN";
         break;
-    case ColumnType::numeric:
+    case column_type::numeric:
         *str = "NUMERIC(12,2)";
         break;
-    case ColumnType::timestamptz:
+    case column_type::timestamptz:
         *str = "TIMESTAMPTZ";
         break;
-    case ColumnType::id:
+    case column_type::id:
         *str = "VARCHAR(36)";
         break;
-    case ColumnType::varchar:
+    case column_type::varchar:
         *str = "VARCHAR(65535)";
         break;
     default:
@@ -534,9 +534,11 @@ void ColumnSchema::columnTypeToString(ColumnType type, string* str)
     }
 }
 
-bool ColumnSchema::selectColumnType(ldp_log* lg, const string& table,
-        const string& source_path, const string& field, const Counts& counts,
-        ColumnType* ctype)
+bool column_schema::select_type(ldp_log* lg, const string& table,
+                                const string& source_path,
+                                const string& field,
+                                const type_counts& counts,
+                                column_type* ctype)
 {
     // Check for incompatible types.
     if (counts.string > 0 && counts.number > 0) {
@@ -553,32 +555,32 @@ bool ColumnSchema::selectColumnType(ldp_log* lg, const string& table,
     // Select a type.
     if (counts.string > 0) {
         if (counts.string == counts.uuid) {
-            *ctype = ColumnType::id;
+            *ctype = column_type::id;
             return true;
         } else {
-            if (counts.string == counts.dateTime) {
-                *ctype = ColumnType::timestamptz;
+            if (counts.string == counts.date_time) {
+                *ctype = column_type::timestamptz;
                 return true;
             } else {
-                *ctype = ColumnType::varchar;
+                *ctype = column_type::varchar;
                 return true;
             }
         }
     }
     if (counts.number > 0) {
         if (counts.floating > 0) {
-            *ctype = ColumnType::numeric;
+            *ctype = column_type::numeric;
             return true;
         } else {
-            *ctype = ColumnType::bigint;
+            *ctype = column_type::bigint;
             return true;
         }
     }
     if (counts.boolean > 0) {
-        *ctype = ColumnType::boolean;
+        *ctype = column_type::boolean;
         return true;
     }
-    *ctype = ColumnType::varchar;
+    *ctype = column_type::varchar;
     return true;
 }
 

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -90,6 +90,13 @@ void ldp_schema::make_default_schema(ldp_schema* schema)
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
+    table.module_name = "mod-email";
+
+    table.source_spec = "/email";
+    table.name = "email_email";
+    schema->tables.push_back(table);
+
+    ///////////////////////////////////////////////////////////////////////////
     table.module_name = "mod-feesfines";
 
     table.source_spec = "/accounts";

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -145,19 +145,18 @@ void ldp_schema::make_default_schema(ldp_schema* schema)
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
-/*
     table.module_name = "mod-courses";
+
+    table.source_spec = "/coursereserves/copyrightstatuses";
+    table.name = "course_copyrightstatuses";
+    schema->tables.push_back(table);
 
     table.source_spec = "/coursereserves/courselistings";
     table.name = "course_courselistings";
     schema->tables.push_back(table);
 
-    table.source_spec = "/coursereserves/roles";
-    table.name = "course_roles";
-    schema->tables.push_back(table);
-
-    table.source_spec = "/coursereserves/terms";
-    table.name = "course_terms";
+    table.source_spec = "/coursereserves/courses";
+    table.name = "course_courses";
     schema->tables.push_back(table);
 
     table.source_spec = "/coursereserves/coursetypes";
@@ -172,18 +171,17 @@ void ldp_schema::make_default_schema(ldp_schema* schema)
     table.name = "course_processingstatuses";
     schema->tables.push_back(table);
 
-    table.source_spec = "/coursereserves/copyrightstatuses";
-    table.name = "course_copyrightstatuses";
-    schema->tables.push_back(table);
-
-    table.source_spec = "/coursereserves/courses";
-    table.name = "course_courses";
-    schema->tables.push_back(table);
-
     table.source_spec = "/coursereserves/reserves";
     table.name = "course_reserves";
     schema->tables.push_back(table);
-*/
+
+    table.source_spec = "/coursereserves/roles";
+    table.name = "course_roles";
+    schema->tables.push_back(table);
+
+    table.source_spec = "/coursereserves/terms";
+    table.name = "course_terms";
+    schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
     table.module_name = "mod-finance-storage";
@@ -583,5 +581,4 @@ bool column_schema::select_type(ldp_log* lg, const string& table,
     *ctype = column_type::varchar;
     return true;
 }
-
 

--- a/src/schema.h
+++ b/src/schema.h
@@ -64,3 +64,4 @@ public:
 };
 
 #endif
+

--- a/src/schema.h
+++ b/src/schema.h
@@ -35,7 +35,7 @@ public:
     ColumnType columnType;
     string sourceColumnName;
     static void columnTypeToString(ColumnType type, string* str);
-    static bool selectColumnType(log* lg, const string& table,
+    static bool selectColumnType(ldp_log* lg, const string& table,
             const string& source_path, const string& field,
             const Counts& counts, ColumnType* ctype);
 };

--- a/src/schema.h
+++ b/src/schema.h
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-enum class ColumnType {
+enum class column_type {
     bigint,
     boolean,
     id,
@@ -17,10 +17,10 @@ enum class ColumnType {
     varchar
 };
 
-class Counts {
+class type_counts {
 public:
     unsigned int string = 0;
-    unsigned int dateTime = 0;
+    unsigned int date_time = 0;
     unsigned int number = 0;
     unsigned int integer = 0;
     unsigned int floating = 0;
@@ -29,38 +29,38 @@ public:
     unsigned int uuid = 0;
 };
 
-class ColumnSchema {
+class column_schema {
 public:
-    string columnName;
-    ColumnType columnType;
-    string sourceColumnName;
-    static void columnTypeToString(ColumnType type, string* str);
-    static bool selectColumnType(ldp_log* lg, const string& table,
-            const string& source_path, const string& field,
-            const Counts& counts, ColumnType* ctype);
+    string name;
+    column_type type;
+    string source_name;
+    static void type_to_string(column_type type, string* str);
+    static bool select_type(ldp_log* lg, const string& table,
+                            const string& source_path, const string& field,
+                            const type_counts& counts, column_type* ctype);
 };
 
-enum class SourceType {
+enum class data_source_type {
     rmb,
-    rmbMarc
+    rmb_marc
 };
 
-class TableSchema {
+class table_schema {
 public:
     bool skip = false;
     bool anonymize = false;
-    string tableName;
-    string sourcePath;
-    SourceType sourceType;
-    vector<ColumnSchema> columns;
-    string moduleName;
-    string directSourceTable;
+    string name;
+    string source_spec;
+    data_source_type source_type;
+    vector<column_schema> columns;
+    string module_name;
+    string direct_source_table;
 };
 
-class Schema {
+class ldp_schema {
 public:
-    vector<TableSchema> tables;
-    static void make_default_schema(Schema* schema);
+    vector<table_schema> tables;
+    static void make_default_schema(ldp_schema* schema);
 };
 
 #endif

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -627,9 +627,10 @@ static void create_loading_table(const ldp_options& opt, ldp_log* lg,
     conn->exec(sql);
 }
 
-bool stage_table(const ldp_options& opt, ldp_log* lg, table_schema* table,
-                 etymon::odbc_env* odbc, etymon::odbc_conn* conn, dbtype* dbt,
-                 const string& load_dir, bool anonymize_fields)
+bool stage_table(const ldp_options& opt, const data_source& source,
+                 ldp_log* lg, table_schema* table, etymon::odbc_env* odbc,
+                 etymon::odbc_conn* conn, dbtype* dbt, const string& load_dir,
+                 bool anonymize_fields)
 {
     size_t page_count = read_page_count(opt, lg, load_dir, table->name);
 
@@ -660,7 +661,7 @@ bool stage_table(const ldp_options& opt, ldp_log* lg, table_schema* table,
                     to_string(page), -1);
             stage_page(opt, lg, pass, *table, odbc, conn, *dbt, &stats, path,
                       read_buffer, sizeof read_buffer, anonymize_fields,
-                      opt.tenant_id);
+                      source.tenant_id);
         }
 
         if (opt.load_from_dir != "") {
@@ -673,7 +674,7 @@ bool stage_table(const ldp_options& opt, ldp_log* lg, table_schema* table,
                         ": test file", -1);
                 stage_page(opt, lg, pass, *table, odbc, conn, *dbt, &stats,
                           path, read_buffer, sizeof read_buffer,
-                          anonymize_fields, opt.tenant_id);
+                          anonymize_fields, source.tenant_id);
             }
         }
 

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -890,9 +890,8 @@ bool stage_table_2(const ldp_options& opt,
         }
     }
 
-    // TODO Re-enable after test
-    //if (pass == 2)
-    //    index_loading_table(lg, *table, conn, dbt);
+    if (pass == 2)
+        index_loading_table(lg, *table, conn, dbt);
 
     return true;
 }

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -890,8 +890,9 @@ bool stage_table_2(const ldp_options& opt,
         }
     }
 
-    if (pass == 2)
-        index_loading_table(lg, *table, conn, dbt);
+    // TODO Re-enable after test
+    //if (pass == 2)
+    //    index_loading_table(lg, *table, conn, dbt);
 
     return true;
 }

--- a/src/stage.h
+++ b/src/stage.h
@@ -3,9 +3,10 @@
 
 #include "options.h"
 
-bool stage_table(const ldp_options& opt, ldp_log* lg, table_schema* table,
-                 etymon::odbc_env* odbc, etymon::odbc_conn* conn, dbtype* dbt,
-                 const string& loadDir, bool anonymize_fields);
+bool stage_table(const ldp_options& opt, const data_source& source,
+                 ldp_log* lg, table_schema* table, etymon::odbc_env* odbc,
+                 etymon::odbc_conn* conn, dbtype* dbt, const string& loadDir,
+                 bool anonymize_fields);
 
 #endif
 

--- a/src/stage.h
+++ b/src/stage.h
@@ -2,8 +2,21 @@
 #define LDP_STAGE_H
 
 #include "options.h"
+#include "util.h"
 
-bool stage_table(const ldp_options& opt, const data_source& source,
+//bool stage_table(const ldp_options& opt,
+//                 ldp_log* lg, table_schema* table, etymon::odbc_env* odbc,
+//                 etymon::odbc_conn* conn, dbtype* dbt, const string& loadDir,
+//                 bool anonymize_fields);
+
+bool stage_table_1(const ldp_options& opt,
+                   const vector<source_state>& source_states,
+                 ldp_log* lg, table_schema* table, etymon::odbc_env* odbc,
+                 etymon::odbc_conn* conn, dbtype* dbt, const string& loadDir,
+                 bool anonymize_fields);
+
+bool stage_table_2(const ldp_options& opt,
+                   const vector<source_state>& source_states,
                  ldp_log* lg, table_schema* table, etymon::odbc_env* odbc,
                  etymon::odbc_conn* conn, dbtype* dbt, const string& loadDir,
                  bool anonymize_fields);

--- a/src/stage.h
+++ b/src/stage.h
@@ -4,7 +4,7 @@
 #include "../etymoncpp/include/postgres.h"
 #include "options.h"
 
-bool stageTable(const ldp_options& opt, ldp_log* lg, TableSchema* table,
+bool stageTable(const ldp_options& opt, ldp_log* lg, table_schema* table,
         etymon::odbc_env* odbc, etymon::odbc_conn* conn, dbtype* dbt,
                 const string& loadDir, bool anonymize_fields);
 

--- a/src/stage.h
+++ b/src/stage.h
@@ -1,12 +1,11 @@
 #ifndef LDP_STAGE_H
 #define LDP_STAGE_H
 
-#include "../etymoncpp/include/postgres.h"
 #include "options.h"
 
-bool stageTable(const ldp_options& opt, ldp_log* lg, table_schema* table,
-        etymon::odbc_env* odbc, etymon::odbc_conn* conn, dbtype* dbt,
-                const string& loadDir, bool anonymize_fields);
+bool stage_table(const ldp_options& opt, ldp_log* lg, table_schema* table,
+                 etymon::odbc_env* odbc, etymon::odbc_conn* conn, dbtype* dbt,
+                 const string& loadDir, bool anonymize_fields);
 
 #endif
 

--- a/src/stage.h
+++ b/src/stage.h
@@ -4,9 +4,9 @@
 #include "../etymoncpp/include/postgres.h"
 #include "options.h"
 
-bool stageTable(const ldp_options& opt, log* lg, TableSchema* table,
+bool stageTable(const ldp_options& opt, ldp_log* lg, TableSchema* table,
         etymon::odbc_env* odbc, etymon::odbc_conn* conn, dbtype* dbt,
-        const string& loadDir);
+                const string& loadDir, bool anonymize_fields);
 
 #endif
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -331,12 +331,6 @@ void run_update(const ldp_options& opt)
     bool enable_anonymization = is_anonymization_enabled(opt, &odbc, opt.db,
                                                          &lg);
 
-    // For LDP 1.0:
-    // if (!ldpconfig_disable_anonymization)
-    //     throw runtime_error(
-    //             "This version requires disable_anonymization in "
-    //             "ldpconfig.general");
-
     for (auto& table : schema.tables) {
 
         // Skip this table if the --table option is specified and does not

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -453,13 +453,10 @@ void run_update(const ldp_options& opt)
 
         bool detect_foreign_keys = false;
         bool force_foreign_key_constraints = false;
-        //bool enable_foreign_key_warnings = false;
+        bool enable_foreign_key_warnings = false;
 
-        ///////////////////////////////////////////////////////////////////////
-        // Temporarily removed until 1.0 release.
-        //select_config_general(&conn, &lg, &detect_foreign_keys,
-        //        &force_foreign_key_constraints, &enable_foreign_key_warnings);
-        ///////////////////////////////////////////////////////////////////////
+        select_config_general(&conn, &lg, &detect_foreign_keys,
+               &force_foreign_key_constraints, &enable_foreign_key_warnings);
 
         if (detect_foreign_keys) {
 
@@ -544,4 +541,3 @@ void run_update_process(const ldp_options& opt)
         exit(1);
     }
 }
-

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -266,9 +266,10 @@ bool is_anonymization_enabled(const ldp_options& opt, etymon::odbc_env* odbc,
         }
     }
 
-    //if (opt.disable_anonymization != ldpconf_disable_anon)
-    //    lg->warning(
-    //        "Configuration settings disable_anonymization do not match");
+    if (opt.disable_anonymization != ldpconf_disable_anon)
+        lg->warning(
+            "Configuration settings for disable_anonymization do not match:\n"
+            "    Action: Anonymization not disabled");
 
     return (!opt.disable_anonymization || !ldpconf_disable_anon);
 }

--- a/src/update.h
+++ b/src/update.h
@@ -1,11 +1,7 @@
 #ifndef LDP_UPDATE_H
 #define LDP_UPDATE_H
 
-#include <string>
-
 #include "options.h"
-
-using namespace std;
 
 void run_update_process(const ldp_options& opt);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,9 +1,6 @@
-#include <cstring>
-
-#include "../etymoncpp/include/util.h"
 #include "util.h"
 
-bool isUUID(const char* str)
+bool is_uuid(const char* str)
 {
     if (strlen(str) != 36)
         return false;
@@ -80,16 +77,3 @@ void print(Print level, const ldp_options& opt, const string& str)
     }
 }
 
-void printSQL(Print level, const ldp_options& opt, const string& sql)
-{
-    print(level, opt, string("sql:\n") + sql);
-}
-
-void printSchema(FILE* stream, const ldp_schema& schema)
-{
-    fprintf(stream, "Module name,Source path,Table name\n");
-    for (const auto& table : schema.tables) {
-        fprintf(stream, "%s,%s,%s\n", table.module_name.c_str(),
-                table.source_spec.c_str(), table.name.c_str());
-    }
-}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -85,11 +85,11 @@ void printSQL(Print level, const ldp_options& opt, const string& sql)
     print(level, opt, string("sql:\n") + sql);
 }
 
-void printSchema(FILE* stream, const Schema& schema)
+void printSchema(FILE* stream, const ldp_schema& schema)
 {
     fprintf(stream, "Module name,Source path,Table name\n");
     for (const auto& table : schema.tables) {
-        fprintf(stream, "%s,%s,%s\n", table.moduleName.c_str(),
-                table.sourcePath.c_str(), table.tableName.c_str());
+        fprintf(stream, "%s,%s,%s\n", table.module_name.c_str(),
+                table.source_spec.c_str(), table.name.c_str());
     }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -51,6 +51,15 @@ void print_banner_line(FILE* stream, char ch, int width)
     fputc('\n', stream);
 }
 
+source_state::source_state(data_source source)
+{
+    this->source = source;
+}
+
+source_state::~source_state()
+{
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Old error printing functions
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -70,11 +70,11 @@ void print(Print level, const ldp_options& opt, const string& str)
     //    fprintf(opt.err, "%s: %s\n", opt.prog, s.c_str());
     //    break;
     case Print::verbose:
-        if (opt.log_level == level::trace)
+        if (opt.lg_level == log_level::trace)
             fprintf(opt.err, "%s: %s\n", opt.prog, s.c_str());
         break;
     case Print::debug:
-        if (opt.log_level == level::trace)
+        if (opt.lg_level == log_level::trace)
             fprintf(opt.err, "%s: %s\n", opt.prog, s.c_str());
         break;
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "util.h"
 
 bool is_uuid(const char* str)

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,6 @@ enum class Print {
 void print(Print level, const ldp_options& opt, const string& str);
 void printSQL(Print level, const ldp_options& opt, const string& sql);
 
-void printSchema(FILE* stream, const Schema& schema);
+void printSchema(FILE* stream, const ldp_schema& schema);
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -1,15 +1,9 @@
 #ifndef LDP_UTIL_H
 #define LDP_UTIL_H
 
-#include <chrono>
-#include <string>
-
 #include "options.h"
-#include "schema.h"
 
-using namespace std;
-
-bool isUUID(const char* str);
+bool is_uuid(const char* str);
 
 void print_banner_line(FILE* stream, char ch, int width);
 
@@ -24,8 +18,6 @@ enum class Print {
 };
 
 void print(Print level, const ldp_options& opt, const string& str);
-void printSQL(Print level, const ldp_options& opt, const string& sql);
-
-void printSchema(FILE* stream, const ldp_schema& schema);
 
 #endif
+

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,14 @@ bool is_uuid(const char* str);
 
 void print_banner_line(FILE* stream, char ch, int width);
 
+class source_state {
+public:
+    data_source source;
+    string token;
+    source_state(data_source source);
+    ~source_state();
+};
+
 ////////////////////////////////////////////////////////////////////////////
 // Old error printing functions
 

--- a/testint/main_testint.cpp
+++ b/testint/main_testint.cpp
@@ -13,7 +13,7 @@ string datadir;
 void safety_checks(char* argv0)
 {
     ldp_options opt;
-    config conf(datadir + "/ldpconf.json");
+    ldp_config conf(datadir + "/ldpconf.json");
     config_options(conf, &opt);
     if (opt.deploy_env != deployment_environment::testing &&
             opt.deploy_env != deployment_environment::development) {


### PR DESCRIPTION
* Course reserves data have been added for FOLIO LDP instances, with table names beginning with `course_`.
* Email data have been added for FOLIO LDP instances, in table `email_email`.
* A bug has been fixed that could cause incomplete database transactions to run into the next transaction.
* The optional `--no-update` flag has been added for use with `ldp init-database` to specify that full updates should be disabled by default.  This flag is for use with upcoming consortial support.
* The optional `tenant_id` configuration setting has been added, for use in upcoming consortial support.
* Partial support for anonymization has been enabled.
* A minimal test framework has been enabled.