### PR TITLE
Define primary key for empty tables

### DIFF
--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -222,7 +222,8 @@ void server_loop(const ldp_options& opt, etymon::odbc_env* odbc)
 
     do {
         if (opt.cli_mode || time_for_full_update(opt, &conn, &dbt, &lg) ) {
-            reschedule_next_daily_load(opt, &conn, &dbt, &lg);
+            if (!opt.cli_mode)
+                reschedule_next_daily_load(opt, &conn, &dbt, &lg);
             pid_t pid = fork();
             if (pid == 0)
                 run_update_process(opt);

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -577,6 +577,16 @@ static void index_loading_table(ldp_log* lg, const table_schema& table,
     lg->trace("Creating indexes on table: " + table.name);
     string loading_table;
     loading_table_name(table.name, &loading_table);
+    // If there is no table schema, define a primary key on (id) and return.
+    if (table.columns.size() == 0) {
+        string sql =
+            "ALTER TABLE " + loading_table + "\n"
+            "    ADD PRIMARY KEY (id);";
+        lg->detail(sql);
+        conn->exec(sql);
+        return;
+    }
+    // If there is a table schema, define the primary key or indexes.
     for (const auto& column : table.columns) {
         if (column.type == column_type::id) {
             if (column.name == "id") {


### PR DESCRIPTION
Defining primary keys for all tables prevents Microsoft Access from asking the user to select keys.