### PR TITLE
Add missing primary keys for empty tables

### DIFF
--- a/src/ldp.cpp
+++ b/src/ldp.cpp
@@ -217,7 +217,8 @@ void server_loop(const ldp_options& opt, etymon::odbc_env* odbc)
 
     do {
         if (opt.cli_mode || time_for_full_update(opt, &conn, &dbt, &lg) ) {
-            reschedule_next_daily_load(opt, &conn, &dbt, &lg);
+            if (!opt.cli_mode)
+                reschedule_next_daily_load(opt, &conn, &dbt, &lg);
             pid_t pid = fork();
             if (pid == 0)
                 run_update_process(opt);

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -545,6 +545,16 @@ static void indexLoadingTable(log* lg, const TableSchema& table,
     lg->trace("Creating indexes on table: " + table.tableName);
     string loadingTable;
     loadingTableName(table.tableName, &loadingTable);
+    // If there is no table schema, define a primary key on (id) and return.
+    if (table.columns.size() == 0) {
+        string sql =
+            "ALTER TABLE " + loadingTable + "\n"
+            "    ADD PRIMARY KEY (id);";
+        lg->detail(sql);
+        conn->exec(sql);
+        return;
+    }
+    // If there is a table schema, define the primary key or indexes.
     for (const auto& column : table.columns) {
         if (column.columnType == ColumnType::id) {
             if (column.columnName == "id") {


### PR DESCRIPTION
* Primary keys are now defined for empty tables, preventing Microsoft Access from asking the user to select a key.
* The attribute `ldpconfig.next_full_update` is no longer modified when running a full update via the command line.