### PR TITLE
Vacuum tables and index more columns

### DIFF
--- a/src/update.cpp
+++ b/src/update.cpp
@@ -447,6 +447,30 @@ void run_update(const ldp_options& opt)
     lg.write(level::debug, "server", "", "Completed full update",
             full_update_timer.elapsed_time());
 
+    // Vacuum and analyze all updated tables
+    {
+        etymon::odbc_conn conn(&odbc, opt.db);
+        timer vacuum_analyze_timer(opt);
+        for (auto& table : schema.tables) {
+            if (table.skip || opt.extract_only)
+                continue;
+            string sql = "VACUUM " + table.tableName + ";";
+            lg.detail(sql);
+            conn.exec(sql);
+            sql = "ANALYZE " + table.tableName + ";";
+            lg.detail(sql);
+            conn.exec(sql);
+            sql = "VACUUM history." + table.tableName + ";";
+            lg.detail(sql);
+            conn.exec(sql);
+            sql = "ANALYZE history." + table.tableName + ";";
+            lg.detail(sql);
+            conn.exec(sql);
+        }
+        lg.write(level::debug, "server", "", "Completed vacuum/analyze",
+                 vacuum_analyze_timer.elapsed_time());
+    }
+
     // TODO Move analysis and constraints out of update process.
     {
         etymon::odbc_conn conn(&odbc, opt.db);


### PR DESCRIPTION
* All updated tables are now vacuumed and analyzed after a full update, to ensure they are immediately ready for use.
* In PostgreSQL-based LDP instances, more columns are now indexed to improve query performance for large tables.