### PR TITLE
Fix omission of instructor data in course reserves

### DIFF
--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -67,7 +67,7 @@ bool data_to_filter(const table_schema& table, const string& field)
         return false;
     if (!ends_with(field, "Object") && !ends_with(field, "Objects"))
         return false;
-    if (table.name == "course_courselistings" && field == "instructorObjects")
+    if (table.name == "course_courselistings" && strncmp(field.data(), "/instructorObjects", 18) == 0)
         return false;
     return true;
 }

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -67,6 +67,8 @@ bool data_to_filter(const table_schema& table, const string& field)
         return false;
     if (!ends_with(field, "Object") && !ends_with(field, "Objects"))
         return false;
+    if (table.name == "course_courselistings" && field == "instructorObjects")
+        return false;
     return true;
 }
 


### PR DESCRIPTION
The course reserves module denormalizes JSON data into fields with names ending in `Object` or `Objects`.  These redundant fields are removed by LDP.  However, `instructorObjects`, which contains instructor data, is a special case because the data are not otherwise retrieved.  This change prevents removal of `instructorObjects`.  Closes #200.