### PR TITLE
Add new table configuration_entries

### DIFF
--- a/src/dbup1.cpp
+++ b/src/dbup1.cpp
@@ -1373,3 +1373,19 @@ void database_upgrade_20(database_upgrade_options* opt)
     tx.commit();
     ulog_commit(opt);
 }
+
+void database_upgrade_21(database_upgrade_options* opt)
+{
+    dbtype dbt(opt->conn);
+
+    etymon::odbc_tx tx(opt->conn);
+
+    upgrade_add_new_table_dbsystem("configuration_entries", opt, dbt, false);
+
+    string sql = "UPDATE dbsystem.main SET database_version = 21;";
+    ulog_sql(sql, opt);
+    opt->conn->exec(sql);
+
+    tx.commit();
+    ulog_commit(opt);
+}

--- a/src/dbup1.h
+++ b/src/dbup1.h
@@ -23,6 +23,7 @@ void database_upgrade_17(database_upgrade_options* opt);
 void database_upgrade_18(database_upgrade_options* opt);
 void database_upgrade_19(database_upgrade_options* opt);
 void database_upgrade_20(database_upgrade_options* opt);
+void database_upgrade_21(database_upgrade_options* opt);
 
 void ulog_sql(const string& sql, database_upgrade_options* opt);
 void ulog_commit(database_upgrade_options* opt);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,7 +12,7 @@
 
 namespace fs = std::experimental::filesystem;
 
-static int64_t ldp_latest_database_version = 20;
+static int64_t ldp_latest_database_version = 21;
 
 database_upgrade_array database_upgrades[] = {
     nullptr,  // Version 0 has no migration.
@@ -35,7 +35,8 @@ database_upgrade_array database_upgrades[] = {
     database_upgrade_17,
     database_upgrade_18,
     database_upgrade_19,
-    database_upgrade_20
+    database_upgrade_20,
+    database_upgrade_21
 };
 
 int64_t latest_database_version()

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -93,7 +93,9 @@ void ldp_schema::make_default_schema(ldp_schema* schema)
 
     table.source_spec = "/configurations/entries";
     table.name = "configuration_entries";
+    table.anonymize = true;
     schema->tables.push_back(table);
+    table.anonymize = false;
 
     // No data found in reference environment
     // table.source_spec = "/configurations/audit";

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -89,6 +89,18 @@ void ldp_schema::make_default_schema(ldp_schema* schema)
     schema->tables.push_back(table);
 
     ///////////////////////////////////////////////////////////////////////////
+    table.module_name = "mod-configuration";
+
+    table.source_spec = "/configurations/entries";
+    table.name = "configuration_entries";
+    schema->tables.push_back(table);
+
+    // No data found in reference environment
+    // table.source_spec = "/configurations/audit";
+    // table.name = "configuration_audit";
+    // schema->tables.push_back(table);
+
+    ///////////////////////////////////////////////////////////////////////////
     table.module_name = "mod-email";
 
     table.source_spec = "/email";


### PR DESCRIPTION
A new table `configuration_entries` has been added for interface `/configurations/entries` provided by module `mod-configuration`.