### PR TITLE
Update Dockerfile to install libpq5 and libcurl4 for ldp runtime.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DATADIR=/var/lib/ldp
 
 RUN mkdir -p $DATADIR
 
-RUN apt update -y && apt install -y libcurl4-openssl-dev
+RUN apt update -y && apt install -y libcurl4 libpq5
 
 COPY ./build/ldp /bin/ldp
 


### PR DESCRIPTION
No need for dev headers, but libpq5 is required. Towards FOLIO-3152